### PR TITLE
Add cloudinit support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,11 @@ go 1.12
 require (
 	github.com/apex/log v1.9.0
 	github.com/cloudflare/cfssl v1.5.0
+	github.com/coreos/coreos-cloudinit v1.14.0
+	github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200417035958-130b0bc6032c+incompatible // indirect
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20200612180813-9e99af28df21 // indirect
+	github.com/elotl/cloud-init v1.14.2
 	github.com/googleapis/gnostic v0.2.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
+github.com/coreos/coreos-cloudinit v1.14.0 h1:3bQRJaie3QC8EovAVbxiimLQgdxM6DxP1vJfUCEEl9w=
+github.com/coreos/coreos-cloudinit v1.14.0/go.mod h1:hV3swhSwq+bRX5apuk57gG+3fsQacgbrZVxjPTqo0zo=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -125,6 +127,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 h1:/1sjrpK5Mb6IwyFOKd+u7321tXfNAsj0Ci8CivZmSlo=
+github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269/go.mod h1:Bl1D/T9QJhVdu6eFoLrGxN90+admDLGaLz2HXH/VzDc=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -174,6 +178,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elotl/cloud-init v1.14.2 h1:MsePTg+R45gxo8Y5Rmms/XwRHh61wdvD+4MDCisw7yo=
+github.com/elotl/cloud-init v1.14.2/go.mod h1:oCbqtZwJTJn+m5kxlJPcAJ5BjOLQuDm0Tw9IzT11XL8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=

--- a/pkg/plugins/file_decoder.go
+++ b/pkg/plugins/file_decoder.go
@@ -1,0 +1,25 @@
+package plugins
+
+type decoder interface {
+	Decode(content string) ([]byte, error)
+}
+
+func newDecoder(s string) decoder {
+	switch s {
+	case "b64", "base64":
+		return base64Decoder{}
+	case "gz", "gzip":
+		return gzipDecoder{}
+	case "gz+base64", "gzip+base64", "gz+b64", "gzip+b64":
+		return base64GZip{}
+	default:
+		return byteDecoder{}
+	}
+}
+
+type byteDecoder struct {
+}
+
+func (byteDecoder) Decode(content string) ([]byte, error) {
+	return []byte(content), nil
+}

--- a/pkg/plugins/file_gzip_decoder.go
+++ b/pkg/plugins/file_gzip_decoder.go
@@ -1,0 +1,28 @@
+package plugins
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+type gzipDecoder struct{}
+
+func (gzipDecoder) Decode(content string) ([]byte, error) {
+	gzr, err := gzip.NewReader(bytes.NewReader([]byte(content)))
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode gzip: %q", err)
+	}
+	defer func() {
+		if err := gzr.Close(); err != nil {
+			logrus.Errorf("unable to close gzip reader: %q", err)
+		}
+	}()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(gzr); err != nil {
+		return nil, fmt.Errorf("unable to read gzip: %q", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/plugins/files_base64_decoder.go
+++ b/pkg/plugins/files_base64_decoder.go
@@ -1,0 +1,32 @@
+package plugins
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type base64Decoder struct{}
+
+func (base64Decoder) Decode(content string) ([]byte, error) {
+	output, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode base64: %q", err)
+	}
+	return output, nil
+}
+
+type base64GZip struct{}
+
+func (base64GZip) Decode(content string) ([]byte, error) {
+	b := base64Decoder{}
+	c, err := b.Decode(content)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "while reading base64 data")
+	}
+
+	g := gzipDecoder{}
+
+	return g.Decode(string(c))
+}

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -11,7 +11,65 @@ import (
 	"github.com/twpayne/go-vfs"
 )
 
-func setUser(username, password string, console Console) error {
+func createUser(u schema.User, console Console) error {
+	var reserr error
+	args := []string{}
+
+	if u.GECOS != "" {
+		args = append(args, "-g", fmt.Sprintf("%q", u.GECOS))
+	}
+
+	if u.Homedir != "" {
+		args = append(args, "-h", u.Homedir)
+	}
+
+	if u.NoCreateHome {
+		args = append(args, "-H")
+	}
+
+	if u.PrimaryGroup != "" {
+		args = append(args, "-G", u.PrimaryGroup)
+	}
+
+	if u.System {
+		args = append(args, "-S")
+	}
+
+	if u.Shell != "" {
+		args = append(args, "-s", u.Shell)
+	}
+
+	args = append(args, "-D")
+	args = append(args, u.Name)
+
+	adduserCmd := []string{"adduser"}
+	output, err := console.Run(strings.Join(append(adduserCmd, args...), " "))
+	if err != nil {
+		reserr = multierror.Append(reserr, err)
+		log.Printf("Command 'useradd %s' failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	if len(u.Groups) > 0 {
+		for _, group := range u.Groups {
+			args := []string{u.Name, group}
+			output, err := console.Run(strings.Join(append(adduserCmd, args...), " "))
+			if err != nil {
+				reserr = multierror.Append(reserr, err)
+
+				log.Printf("Command 'adduser %s' failed: %v\n%s", strings.Join(args, " "), err, output)
+			}
+		}
+	}
+	if u.PasswordHash != "" {
+		err := setUserPassword(u.Name, u.PasswordHash, console)
+		if err != nil {
+			reserr = multierror.Append(reserr, err)
+			log.Printf("Error setting password for %s: %v\n", u.Name, err)
+		}
+	}
+	return reserr
+}
+
+func setUserPassword(username, password string, console Console) error {
 	if password == "" {
 		return nil
 	}
@@ -34,8 +92,15 @@ func User(s schema.Stage, fs vfs.FS, console Console) error {
 	var errs error
 
 	for u, p := range s.Users {
-		if err := setUser(u, p, console); err != nil {
-			errs = multierror.Append(errs, err)
+		p.Name = u
+		if !p.Exists() {
+			if err := createUser(p, console); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		} else {
+			if err := setUserPassword(u, p.PasswordHash, console); err != nil {
+				errs = multierror.Append(errs, err)
+			}
 		}
 	}
 	return errs

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -37,11 +37,11 @@ var _ = Describe("User", func() {
 			defer cleanup()
 
 			err = User(schema.Stage{
-				Users: map[string]string{"foo": `$fkekofe`},
+				Users: map[string]schema.User{"foo": {PasswordHash: `$fkekofe`}},
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(consoletests.Stdin).Should(Equal("foo:$fkekofe"))
-			Expect(consoletests.Commands).Should(Equal([]string{"chpasswd", "-e"}))
+			Expect(consoletests.Commands).Should(Equal([]string{"adduser -D foo", "chpasswd", "-e"}))
 		})
 	})
 })

--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -1,0 +1,104 @@
+// Copyright © 2021 Ettore Di Giacinto <mudler@sabayon.org>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package schema
+
+import (
+	cloudconfig "github.com/elotl/cloud-init/config"
+	"github.com/twpayne/go-vfs"
+)
+
+type cloudInit struct{}
+
+// Load transpiles a cloud-init style
+// file ( https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
+// to a yip schema.
+// As Yip supports multi-stages, it is encoded in the supplied one.
+// fs is used to parse the user data required from /etc/passwd.
+func (cloudInit) Load(s []byte, fs vfs.FS) (*YipConfig, error) {
+
+	stage := "boot"
+	cc, err := cloudconfig.NewCloudConfig(string(s))
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode users and SSH Keys
+	sshKeys := make(map[string][]string)
+	users := make(map[string]User)
+	userstoKey := []string{}
+
+	for _, u := range cc.Users {
+		userstoKey = append(userstoKey, u.Name)
+		users[u.Name] = User{
+			Name:         u.Name,
+			PasswordHash: u.PasswordHash,
+			GECOS:        u.GECOS,
+			Homedir:      u.Homedir,
+			NoCreateHome: u.NoCreateHome,
+			PrimaryGroup: u.PrimaryGroup,
+			Groups:       u.Groups,
+			NoUserGroup:  u.NoUserGroup,
+			System:       u.System,
+			NoLogInit:    u.NoLogInit,
+			Shell:        u.Shell,
+		}
+		sshKeys[u.Name] = u.SSHAuthorizedKeys
+	}
+
+	for _, uu := range userstoKey {
+		_, exists := sshKeys[uu]
+		if !exists {
+			sshKeys[uu] = cc.SSHAuthorizedKeys
+		} else {
+			sshKeys[uu] = append(sshKeys[uu], cc.SSHAuthorizedKeys...)
+		}
+	}
+
+	// Decode writeFiles
+	var f []File
+	for _, ff := range cc.WriteFiles {
+		f = append(f,
+			File{
+				Path:        ff.Path,
+				OwnerString: ff.Owner,
+				Content:     ff.Content,
+				Encoding:    ff.Encoding,
+			},
+		)
+	}
+
+	for _, ff := range cc.MilpaFiles {
+		f = append(f,
+			File{
+				Path:        ff.Path,
+				OwnerString: ff.Owner,
+				Content:     ff.Content,
+				Encoding:    ff.Encoding,
+			},
+		)
+	}
+
+	return &YipConfig{
+		Name: "Cloud init",
+		Stages: map[string][]Stage{stage: {{
+			Commands: cc.RunCmd,
+			Files:    f,
+			Hostname: cc.Hostname,
+			Users:    users,
+			SSHKeys:  sshKeys,
+		}}},
+	}, nil
+}

--- a/pkg/schema/loader_yip.go
+++ b/pkg/schema/loader_yip.go
@@ -1,0 +1,19 @@
+package schema
+
+import (
+	"github.com/twpayne/go-vfs"
+	"gopkg.in/yaml.v2"
+)
+
+type yipYAML struct{}
+
+// LoadFromYaml loads a yip config from bytes
+func (yipYAML) Load(b []byte, fs vfs.FS) (*YipConfig, error) {
+	var yamlConfig YipConfig
+	err := yaml.Unmarshal(b, &yamlConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &yamlConfig, nil
+}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -23,6 +23,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func loadstdYip(s string) *YipConfig {
+	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/yip.yaml": s, "/etc/passwd": ""})
+	Expect(err).Should(BeNil())
+	defer cleanup()
+
+	yipConfig, err := Load("/yip.yaml", fs, FromFile, nil)
+	Expect(err).ToNot(HaveOccurred())
+	return yipConfig
+}
+
 func loadYip(s string) *YipConfig {
 	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/yip.yaml": s})
 	Expect(err).Should(BeNil())
@@ -53,6 +63,37 @@ var _ = Describe("Schema", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(yipConfig.Stages["foo"][0].Name).To(Equal("bar"))
 			Expect(yipConfig.Stages["foo"][0].Commands[0]).To(Equal("baz"))
+		})
+	})
+
+	Context("Loading CloudConfig", func() {
+		It("Reads cloudconfig to boot stage", func() {
+			yipConfig := loadstdYip(`#cloud-config
+users:
+- name: "bar"
+  passwd: "foo"
+  groups: "users"
+  ssh_authorized_keys:
+  - faaapploo
+ssh_authorized_keys:
+  - asdd
+runcmd:
+- foo
+hostname: "bar"
+write_files:
+- encoding: b64
+  content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4
+  path: /foo/bar
+  permissions: "0644"
+  owner: "bar"
+`)
+			Expect(len(yipConfig.Stages)).To(Equal(1))
+			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
+			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"faaapploo", "asdd"}}))
+			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
+			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal("bar"))
+			Expect(yipConfig.Stages["boot"][0].Commands).To(Equal([]string{"foo"}))
+
 		})
 	})
 })

--- a/pkg/utils/user.go
+++ b/pkg/utils/user.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	osuser "os/user"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// GetUserDataFromString retrieves uid and gid from a string. The string
+// have to be in the "user:group" syntax, or just "user".
+func GetUserDataFromString(s string) (int, int, error) {
+	user := s
+	var u, g string
+	if strings.Contains(s, ":") {
+		dat := strings.Split(user, ":")
+		us, err := osuser.Lookup(dat[0])
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "while looking up user %s", dat[0])
+		}
+		u = us.Uid
+
+		group, err := osuser.LookupGroup(dat[1])
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "while looking up group %s", dat[1])
+		}
+		g = group.Gid
+	} else {
+		us, err := osuser.Lookup(s)
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "while looking up user %s", s)
+		}
+		u = us.Uid
+		g = us.Gid
+	}
+
+	uid, err := strconv.Atoi(u)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed converting uid to int")
+	}
+
+	gid, err := strconv.Atoi(g)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed converting gid to int")
+	}
+	return uid, gid, nil
+}


### PR DESCRIPTION
Add support for the cloudconfig file syntax, encoding it into the "boot"
yip stage.

Also adds support for more fine-grained control of the user setup and
file encoding when writing files to match cloudinit featureset

Signed-off-by: Ettore Di Giacinto <mudler@sabayon.org>