### PR TITLE
Ensure /run/config is created before extracting

### DIFF
--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -50,6 +50,19 @@ func DataSources(s schema.Stage, fs vfs.FS, console Console) error {
 		}
 	}
 
+	if err := EnsureDirectories(schema.Stage{
+		Directories: []schema.Directory{
+			{
+				Path:        prv.ConfigPath,
+				Permissions: 0755,
+				Owner:       os.Getuid(),
+				Group:       os.Getgid(),
+			},
+		},
+	}, fs, console); err != nil {
+		return err
+	}
+
 	var p prv.Provider
 	var userdata []byte
 	var err error


### PR DESCRIPTION
Pre-create ConfigPath before extracting.

Signed-off-by: David Cassany <dcassany@suse.com>