### PR TITLE
Load user-data as YipConfig files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ stages:
                   info: "Foo!"
                   homedir: "/home/foo"
                   shell: "/bin/bash"
+      datasource:
+        providers:
+          - "digitalocean"
+          - "aws"
+          - "gcp"
+        path: "/usr/local/etc"
 ```
 
 - Simple
@@ -474,4 +480,24 @@ stages:
      - name: "Setup something"
        commands:
          - echo 1 > /bar
+```
+
+### `stages.<stageID>.[<stepN>].datasource`
+
+Sets to fetch user data from the specified cloud providers. It iterates
+through the list of providers and the first one that succeeds to
+extract some user data is the one being used. It populates provider
+specific data into `/run/config` folder and the custom user data is stored
+into the provided path.
+
+
+```yaml
+stages:
+   default:
+     - name: "Fetch cloud provider's user data"
+       datasource:
+         providers:
+           - "aws"
+           - "digitalocean"
+         path: "/etc/cloud-data"
 ```

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -53,7 +53,7 @@ type Directory struct {
 }
 
 type DataSource struct {
-	Type string `yaml:"type"`
+	Providers []string `yaml:"providers"`
 	Path string `yaml:"path"`
 }
 
@@ -96,7 +96,7 @@ type Stage struct {
 	Environment     map[string]string   `yaml:"environment"`
 	EnvironmentFile string              `yaml:"environment_file"`
 
-	DataSources []DataSource `yaml:"datasources"`
+	DataSources DataSource `yaml:"datasource"`
 
 	SystemdFirstBoot map[string]string `yaml:"systemd_firstboot"`
 


### PR DESCRIPTION
This PR tries to load user-data from providers as YipConfig files,
if the parsing fails it does nor raise any error. User-data is stored to
the provided path. The file is named `userdata.yaml` if it could be
parsed as a YipConfig structure otherwise it is just called `userdata`.

In addition this commit also includes logic to apply the authorized keys
if the provider extracts a `ssh/authorized_keys` file.

Fixes rancher-sandbox/cOS-toolkit#93

Signed-off-by: David Cassany <dcassany@suse.com>