### PR TITLE
This commit adds a Layout plugin

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -47,6 +47,7 @@ func NewExecutor(s string) Executor {
 				plugins.Environment,
 				plugins.SystemdFirstboot,
 				plugins.DataSources,
+				plugins.Layout,
 			},
 		}
 	}

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -1,0 +1,617 @@
+package plugins
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mudler/yip/pkg/schema"
+	log "github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs"
+)
+
+type Disk struct {
+	Device  string
+	SectorS uint
+	LastS   uint
+	Parts   []Partition
+}
+
+// We only manage sizes in sectors unit for the Partition struct and sgdisk wrapper
+type Partition struct {
+	Number     int
+	StartS     uint
+	SizeS      uint
+	PLabel     string
+	FileSystem string
+	FSLabel    string
+	Type       string
+}
+
+type GdiskCall struct {
+	dev       string
+	wipe      bool
+	parts     []*Partition
+	deletions []int
+	expand    bool
+	pretend   bool
+}
+
+type MkfsCall struct {
+	part       Partition
+	customOpts []string
+	dev        string
+}
+
+func Layout(s schema.Stage, fs vfs.FS, console Console) error {
+	if s.Layout.Device == nil {
+		return nil
+	}
+
+	dev, err := FindDiskFromPartitionLabel(s.Layout.Device.Label, console)
+	if err != nil {
+		log.Warningf("Exiting, disk not found:\n %s", err.Error())
+		return nil
+	}
+
+	changed := false
+
+	// Check there is a minimum of 32MiB of free space in disk
+	if !dev.CheckDiskFreeSpaceMiB(32, console) {
+		log.Warningf("Not enough unpartitioned space in disk to operate")
+		return nil
+	}
+
+	if s.Layout.Expand != nil {
+		log.Infof("Extending last partition up to %d MiB", s.Layout.Expand.Size)
+		out, err := dev.ExpandLastPartition(s.Layout.Expand.Size, console)
+		if err != nil {
+			log.Error(out)
+			return err
+		}
+		changed = true
+	}
+
+	for _, part := range s.Layout.Parts {
+		if match := MatchPartitionFSLabel(part.FSLabel, console); match != "" {
+			log.Warningf("Partition with FSLabel: %s already exists, ignoring", part.FSLabel)
+			continue
+		} else if match := MatchPartitionPLabel(part.PLabel, console); match != "" {
+			log.Warningf("Partition with PLabel: %s already exists, ignoring", part.PLabel)
+			continue
+		}
+		// Set default filesystem
+		if part.FileSystem == "" {
+			part.FileSystem = "ext2"
+		}
+
+		log.Infof("Creating %s partition", part.FSLabel)
+		out, err := dev.AddPartition(part.FSLabel, part.Size, part.FileSystem, part.PLabel, console)
+		if err != nil {
+			log.Error(out)
+			return err
+		}
+		changed = true
+	}
+
+	if changed {
+		dev.ReloadPartitionTable(console)
+	}
+	return nil
+}
+
+func MatchPartitionFSLabel(label string, console Console) string {
+	if label != "" {
+		out, err := console.Run(fmt.Sprintf("blkid -l --match-token LABEL=%s -o device", label))
+		if err == nil {
+			return out
+		}
+	}
+	return ""
+}
+
+func MatchPartitionPLabel(label string, console Console) string {
+	if label != "" {
+		out, err := console.Run(fmt.Sprintf("blkid -l --match-token PARTLABEL=%s -o device", label))
+		if err == nil {
+			return out
+		}
+	}
+	return ""
+}
+
+func FindDiskFromPartitionLabel(label string, console Console) (Disk, error) {
+	if partnode := MatchPartitionFSLabel(label, console); partnode != "" {
+		device, err := console.Run(fmt.Sprintf("lsblk -npo pkname %s", partnode))
+		if err == nil {
+			return Disk{Device: device}, nil
+		}
+	} else if partnode := MatchPartitionPLabel(label, console); partnode != "" {
+		device, err := console.Run(fmt.Sprintf("lsblk -npo pkname %s", partnode))
+		if err == nil {
+			return Disk{Device: device}, nil
+		}
+	}
+	return Disk{}, errors.New("Could not find device for the given label")
+}
+
+func (dev Disk) String() string {
+	return dev.Device
+}
+
+func (dev *Disk) Reload(console Console) error {
+	gd := NewGdiskCall(dev.String())
+	prnt, err := gd.Print(console)
+	if err != nil {
+		return err
+	}
+
+	sectorS, err := gd.GetSectorSize(prnt)
+	if err != nil {
+		return err
+	}
+	lastS, err := gd.GetLastSector(prnt)
+	if err != nil {
+		return err
+	}
+	partitions := gd.GetPartitions(prnt)
+	dev.SectorS = sectorS
+	dev.LastS = lastS
+	dev.Parts = partitions
+	return nil
+}
+
+// Size is expressed in MiB here
+func (dev *Disk) CheckDiskFreeSpaceMiB(minSpace uint, console Console) bool {
+	freeS, err := dev.GetFreeSpace(console)
+	if err != nil {
+		log.Warningf("Could not calculate disk free space")
+		return false
+	}
+	minSec := MiBToSectors(minSpace, dev.SectorS)
+	if freeS < minSec {
+		return false
+	}
+	return true
+}
+
+func (dev *Disk) GetFreeSpace(console Console) (uint, error) {
+	gd := NewGdiskCall(dev.String())
+	if gd.HasUnallocatedSpace(console) {
+		gd.ExpandPTable()
+		out, err := gd.WriteChanges(console)
+		if err != nil {
+			log.Errorf("Failed resizing the partition table: \n%s", out)
+			return 0, err
+		}
+		err = dev.Reload(console)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	//Check we have loaded partition table data
+	if dev.SectorS == 0 {
+		err := dev.Reload(console)
+		if err != nil {
+			log.Errorf("Failed analyzing disk: %v\n", err)
+			return 0, err
+		}
+	}
+
+	return dev.computeFreeSpace(), nil
+}
+
+func (dev Disk) computeFreeSpace() uint {
+	if len(dev.Parts) > 0 {
+		lastPart := dev.Parts[len(dev.Parts)-1]
+		return dev.LastS - (lastPart.StartS + lastPart.SizeS - 1)
+	} else {
+		// Assume first partitions is alined to 1MiB
+		return dev.LastS - (1024*1024/dev.SectorS - 1)
+	}
+}
+
+func (dev Disk) computeFreeSpaceWithoutLast() uint {
+	if len(dev.Parts) > 1 {
+		part := dev.Parts[len(dev.Parts)-2]
+		return dev.LastS - (part.StartS + part.SizeS - 1)
+	} else {
+		// Assume first partitions is alined to 1MiB
+		return dev.LastS - (1024*1024/dev.SectorS - 1)
+	}
+}
+
+//Size is expressed in MiB here
+func (dev *Disk) AddPartition(label string, size uint, fileSystem string, pLabel string, console Console) (string, error) {
+	gd := NewGdiskCall(dev.String())
+	pType := "8300"
+	if fatFS, _ := regexp.MatchString("fat|vfat", fileSystem); fatFS {
+		// We are assuming Fat is only used for EFI partitions
+		pType = "EF00"
+	}
+
+	//Check we have loaded partition table data
+	if dev.SectorS == 0 {
+		err := dev.Reload(console)
+		if err != nil {
+			log.Errorf("Failed analyzing disk: %v\n", err)
+			return "", err
+		}
+	}
+
+	var partNum int
+	var startS uint
+	if len(dev.Parts) > 0 {
+		partNum = dev.Parts[len(dev.Parts)-1].Number
+		startS = 0
+	} else {
+		//First partition is aligned at 1MiB
+		startS = 1024 * 1024 / dev.SectorS
+	}
+
+	size = MiBToSectors(size, dev.SectorS)
+	freeS := dev.computeFreeSpace()
+	if size > freeS {
+		return "", errors.New(fmt.Sprintf("Not enough free space in disk. Required: %d sectors; Available %d sectors", size, freeS))
+	}
+
+	partNum++
+	var part = Partition{
+		Number:     partNum,
+		StartS:     startS,
+		SizeS:      size,
+		PLabel:     pLabel,
+		FileSystem: fileSystem,
+		FSLabel:    label,
+		Type:       pType,
+	}
+
+	gd.CreatePartition(&part)
+
+	out, err := gd.WriteChanges(console)
+	if err != nil {
+		return out, err
+	}
+	err = dev.Reload(console)
+	if err != nil {
+		log.Errorf("Failed analyzing disk: %v\n", err)
+		return "", err
+	}
+	err = dev.ReloadPartitionTable(console)
+	if err != nil {
+		log.Errorf("Failed on partprobe: %v\n", err)
+		return "", err
+	}
+	pDev, err := dev.FindPartitionDevice(part.Number, console)
+	if err != nil {
+		return "", err
+	}
+
+	mkfs := MkfsCall{part: part, customOpts: []string{}, dev: pDev}
+	return mkfs.Apply(console)
+}
+
+func (dev Disk) ReloadPartitionTable(console Console) error {
+	out, err := console.Run(fmt.Sprintf("partprobe %s", dev))
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not reload partition table: %s", out))
+	}
+	return nil
+}
+
+func (dev Disk) FindPartitionDevice(partNum int, console Console) (string, error) {
+	out, err := console.Run(fmt.Sprintf("lsblk -ltnpo name,type %s", dev))
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Could not list device partition nodes: %s", out))
+	}
+
+	re, err := regexp.Compile(fmt.Sprintf("(?m)^(/.*%d) part$", partNum))
+	if err != nil {
+		return "", errors.New("Failed compiling regexp")
+	}
+	match := re.FindStringSubmatch(out)
+	if match == nil {
+		return "", errors.New(fmt.Sprintf("Could find partition device path for partition %d", partNum))
+	}
+	return match[1], nil
+}
+
+//Size is expressed in MiB here
+func (dev *Disk) ExpandLastPartition(size uint, console Console) (string, error) {
+	if len(dev.Parts) == 0 {
+		return "", errors.New("There is no partition to expand")
+	}
+	gd := NewGdiskCall(dev.String())
+
+	//Check we have loaded partition table data
+	if dev.SectorS == 0 {
+		err := dev.Reload(console)
+		if err != nil {
+			log.Errorf("Failed analyzing disk: %v\n", err)
+			return "", err
+		}
+	}
+
+	size = MiBToSectors(size, dev.SectorS)
+
+	part := dev.Parts[len(dev.Parts)-1]
+	if size < part.SizeS {
+		return "", errors.New("Layout plugin can only expand a partition, not shrink it")
+	}
+	freeS := dev.computeFreeSpaceWithoutLast()
+	if size > freeS {
+		return "", errors.New(fmt.Sprintf("Not enough free space for to expand last partition up to %d sectors", size))
+	}
+	part.SizeS = size
+
+	gd.DeletePartition(part.Number)
+	gd.CreatePartition(&part)
+	out, err := gd.WriteChanges(console)
+	if err != nil {
+		return "", err
+	}
+	err = dev.Reload(console)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func NewGdiskCall(dev string) *GdiskCall {
+	return &GdiskCall{dev: dev, wipe: false, parts: []*Partition{}, deletions: []int{}, expand: false, pretend: false}
+}
+
+func (gd GdiskCall) buildOptions() []string {
+	opts := []string{}
+
+	if gd.pretend {
+		opts = append(opts, "-P")
+	}
+
+	if gd.wipe {
+		opts = append(opts, "--zap-all")
+	}
+
+	if gd.expand {
+		opts = append(opts, "-e")
+	}
+
+	for _, partnum := range gd.deletions {
+		opts = append(opts, fmt.Sprintf("-d=%d", partnum))
+	}
+
+	for _, part := range gd.parts {
+		opts = append(opts, fmt.Sprintf("-n=%d:%d:+%d", part.Number, part.StartS, part.SizeS))
+
+		if part.PLabel != "" {
+			opts = append(opts, fmt.Sprintf("-c=%d:%s", part.Number, part.PLabel))
+		}
+
+		if part.Type != "" {
+			opts = append(opts, fmt.Sprintf("-t=%d:%s", part.Number, part.Type))
+		}
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+
+	opts = append(opts, gd.dev)
+	return opts
+}
+
+func (gd GdiskCall) Verify(console Console) (string, error) {
+	return console.Run(fmt.Sprintf("sgdisk --verify %s", gd.dev))
+}
+
+func (gd GdiskCall) HasUnallocatedSpace(console Console) bool {
+	out, _ := gd.Verify(console)
+	if unallocated, _ := regexp.MatchString("the end of the disk", out); unallocated {
+		return true
+	}
+	return false
+}
+
+func (gd GdiskCall) Print(console Console) (string, error) {
+	return console.Run(fmt.Sprintf("sgdisk -p %s", gd.dev))
+}
+
+func (gd GdiskCall) Info(partNum int, console Console) (string, error) {
+	return console.Run(fmt.Sprintf("sgdisk -i %d %s", partNum, gd.dev))
+}
+
+// Parses the output of a GdiskCall.Print call
+func (gd GdiskCall) GetLastSector(printOut string) (uint, error) {
+	re := regexp.MustCompile("last usable sector is (\\d+)")
+	match := re.FindStringSubmatch(printOut)
+	if match != nil {
+		endS, err := strconv.ParseUint(match[1], 10, 0)
+		return uint(endS), err
+	}
+	return 0, errors.New("Could not determine last usable sector")
+}
+
+// Parses the output of a GdiskCall.Print call
+func (gd GdiskCall) GetSectorSize(printOut string) (uint, error) {
+	re := regexp.MustCompile("sector size: (\\d+)")
+	match := re.FindStringSubmatch(printOut)
+	if match != nil {
+		size, err := strconv.ParseUint(match[1], 10, 0)
+		return uint(size), err
+	}
+	return 0, errors.New("Could not determine sector size")
+}
+
+// Parses the output of a GdiskCall.Print call
+func (gd GdiskCall) GetPartitions(printOut string) []Partition {
+	re := regexp.MustCompile("^(\\d+)\\s+(\\d+)\\s+(\\d+).*(EF02|EF00|8300)\\s*(.*)$")
+	var pType string
+	var start uint
+	var end uint
+	var size uint
+	var pLabel string
+	var partNum int
+	var partitions []Partition
+
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(printOut)))
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
+		if match != nil {
+			partNum, _ = strconv.Atoi(match[1])
+			parsed, _ := strconv.ParseUint(match[2], 10, 0)
+			start = uint(parsed)
+			parsed, _ = strconv.ParseUint(match[3], 10, 0)
+			end = uint(parsed)
+			size = end - start + 1
+			pType = match[4]
+			pLabel = match[5]
+
+			partitions = append(partitions, Partition{
+				Number:     partNum,
+				StartS:     start,
+				SizeS:      size,
+				PLabel:     pLabel,
+				FileSystem: "",
+				FSLabel:    "",
+				Type:       pType,
+			})
+		}
+	}
+	return partitions
+}
+
+func (gd GdiskCall) GetPartitionData(partNum int, console Console) (*Partition, error) {
+	out, err := gd.Info(partNum, console)
+	if err != nil {
+		return nil, err
+	}
+
+	var pType string
+	var start uint
+	var size uint
+	var pLabel string
+	if match, _ := regexp.MatchString("Linux filesystem", out); match {
+		pType = "8300"
+	} else if match, _ = regexp.MatchString("EFI System", out); match {
+		pType = "EF00"
+	}
+	re := regexp.MustCompile("First sector: (\\d+)")
+	match := re.FindStringSubmatch(out)
+	if match == nil {
+		return nil, errors.New("Could not determine start sector")
+	}
+	parsed, _ := strconv.ParseUint(match[1], 10, 0)
+	start = uint(parsed)
+
+	re = regexp.MustCompile("Partition size: (\\d+) sectors")
+	match = re.FindStringSubmatch(out)
+	if match == nil {
+		return nil, errors.New("Could not determine partition size")
+	}
+	parsed, _ = strconv.ParseUint(match[1], 10, 0)
+	size = uint(parsed)
+
+	re = regexp.MustCompile("Partition name: '(.*)'")
+	match = re.FindStringSubmatch(out)
+	if match == nil {
+		return nil, errors.New("Could not determine partition name")
+	}
+	pLabel = match[1]
+
+	part := Partition{
+		Number:     partNum,
+		StartS:     start,
+		SizeS:      size,
+		PLabel:     pLabel,
+		FileSystem: "",
+		FSLabel:    "",
+		Type:       pType,
+	}
+
+	return &part, nil
+}
+
+func (gd *GdiskCall) WriteChanges(console Console) (string, error) {
+	gd.SetPretend(true)
+	opts := gd.buildOptions()
+
+	// Run sgdisk with --pretend flag first to as a sanity check
+	// before any change to disk happens
+	out, err := console.Run(fmt.Sprintf("sgdisk %s", strings.Join(opts[:], " ")))
+	if err != nil {
+		return out, err
+	}
+
+	gd.SetPretend(false)
+	opts = gd.buildOptions()
+	return console.Run(fmt.Sprintf("sgdisk %s", strings.Join(opts[:], " ")))
+}
+
+func (gd *GdiskCall) CreatePartition(p *Partition) {
+	gd.parts = append(gd.parts, p)
+}
+
+func (gd *GdiskCall) SetPretend(pretend bool) {
+	gd.pretend = pretend
+}
+
+func (gd *GdiskCall) DeletePartition(num int) {
+	gd.deletions = append(gd.deletions, num)
+}
+
+func (gd *GdiskCall) WipeTable(wipe bool) {
+	gd.wipe = wipe
+}
+
+func (gd *GdiskCall) ExpandPTable() {
+	gd.expand = true
+}
+
+func (mkfs MkfsCall) buildOptions() ([]string, error) {
+	opts := []string{}
+
+	linuxFS, _ := regexp.MatchString("ext[2-4]|xfs", mkfs.part.FileSystem)
+	fatFS, _ := regexp.MatchString("fat|vfat", mkfs.part.FileSystem)
+
+	switch {
+	case linuxFS:
+		if mkfs.part.FSLabel != "" {
+			opts = append(opts, "-L")
+			opts = append(opts, mkfs.part.FSLabel)
+		}
+		if len(mkfs.customOpts) > 0 {
+			opts = append(opts, mkfs.customOpts...)
+		}
+		opts = append(opts, mkfs.dev)
+	case fatFS:
+		if mkfs.part.FSLabel != "" {
+			opts = append(opts, "-i")
+			opts = append(opts, mkfs.part.FSLabel)
+		}
+		if len(mkfs.customOpts) > 0 {
+			opts = append(opts, mkfs.customOpts...)
+		}
+		opts = append(opts, mkfs.dev)
+	default:
+		return []string{}, errors.New(fmt.Sprintf("Unsupported filesystem: %s", mkfs.part.FileSystem))
+	}
+	return opts, nil
+}
+
+func (mkfs MkfsCall) Apply(console Console) (string, error) {
+	opts, err := mkfs.buildOptions()
+	if err != nil {
+		return "", err
+	}
+	tool := fmt.Sprintf("mkfs.%s", mkfs.part.FileSystem)
+	command := fmt.Sprintf("%s %s", tool, strings.Join(opts[:], " "))
+	return console.Run(command)
+}
+
+func MiBToSectors(size uint, sectorSize uint) uint {
+	return size * 1048576 / sectorSize
+}

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -1,0 +1,146 @@
+package plugins_test
+
+import (
+	. "github.com/mudler/yip/pkg/plugins"
+	"github.com/mudler/yip/pkg/schema"
+	console "github.com/mudler/yip/tests/console"
+	"github.com/twpayne/go-vfs/vfst"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var pTable console.CmdMock = console.CmdMock{
+	Cmd: "sgdisk -p /some/device",
+	Output: `Disk /some/device: 6471680 sectors, 3.1 GiB
+Logical sector size: 512 bytes
+Disk identifier (GUID): D2C09E82-250C-4A75-83B4-184BACC3D879
+Partition table holds up to 128 entries
+First usable sector is 34, last usable sector is 6471646
+Partitions will be aligned on 2048-sector boundaries
+Total free space is 4029 sectors (2.0 MiB)
+
+Number  Start (sector)    End (sector)  Size       Code  Name
+   1            2048            6143   2.0 MiB     EF02  legacy
+   2            6144           47103   20.0 MiB    EF00  UEFI
+   3           47104          178175   64.0 MiB    8300
+   4          178176         4372479   2.0 GiB     8300  root`,
+}
+
+var lsblkTypes console.CmdMock = console.CmdMock{
+	Cmd: "lsblk -ltnpo name,type /some/device",
+	Output: `/some/device  disk
+/some/device1 part
+/some/device2 part
+/some/device5 part`,
+}
+
+var CmdsAddPart []console.CmdMock = []console.CmdMock{
+	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
+	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
+	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
+	{Cmd: "sgdisk -P -e /some/device"},
+	{Cmd: "sgdisk -e /some/device"}, pTable,
+	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
+	{Cmd: "sgdisk -P -n=5:0:+2097152 -t=5:8300 /some/device"},
+	{Cmd: "sgdisk -n=5:0:+2097152 -t=5:8300 /some/device"}, pTable,
+	{Cmd: "partprobe /some/device"}, lsblkTypes,
+	{Cmd: "mkfs.ext2 -L MYLABEL /some/device5"},
+	{Cmd: "partprobe /some/device"},
+	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
+}
+
+var CmdsAddAlreadyExistingPart []console.CmdMock = []console.CmdMock{
+	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
+	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
+	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
+	{Cmd: "sgdisk -P -e /some/device"},
+	{Cmd: "sgdisk -e /some/device"}, pTable,
+	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device", Output: "/some/part"},
+}
+
+var CmdsExpandPart []console.CmdMock = []console.CmdMock{
+	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
+	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
+	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
+	{Cmd: "sgdisk -P -e /some/device"},
+	{Cmd: "sgdisk -e /some/device"}, pTable,
+	{Cmd: "sgdisk -P -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
+	{Cmd: "sgdisk -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"}, pTable,
+	{Cmd: "partprobe /some/device"},
+}
+
+var _ = Describe("Layout", func() {
+	Context("creating", func() {
+		fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
+		Expect(err).Should(BeNil())
+		defer cleanup()
+
+		It("Adds a new partition of 1024MiB in reflabel device", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsAddPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Parts:  []schema.Partition{{FSLabel: "MYLABEL", Size: 1024}},
+				},
+			}, fs, testConsole)
+			Expect(err).Should(BeNil())
+		})
+		It("Fails to add a partition of 1030MiB, there are only 1024MiB available", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsAddPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Parts:  []schema.Partition{{FSLabel: "MYLABEL", Size: 1025}},
+				},
+			}, fs, testConsole)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Ignores an already existing partition", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsAddAlreadyExistingPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Parts:  []schema.Partition{{FSLabel: "MYLABEL", Size: 1024}},
+				},
+			}, fs, testConsole)
+			Expect(err).Should(BeNil())
+		})
+		It("Fails to expand last partition, it can't shrink a partition", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsExpandPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Expand: &schema.Expand{Size: 1024},
+				},
+			}, fs, testConsole)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Expands last partition", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsExpandPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Expand: &schema.Expand{Size: 3072},
+				},
+			}, fs, testConsole)
+			Expect(err).Should(BeNil())
+		})
+		It("Fails to expand last partition, max size is 3072MiB", func() {
+			testConsole := console.New()
+			testConsole.AddCmds(CmdsExpandPart)
+			err := Layout(schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Label: "reflabel"},
+					Expand: &schema.Expand{Size: 3073},
+				},
+			}, fs, testConsole)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -77,6 +77,27 @@ func (u User) Exists() bool {
 	return err == nil
 }
 
+type Layout struct {
+	Device *Device     `yaml:"device"`
+	Expand *Expand     `yaml:"expand_partition,omitempty"`
+	Parts  []Partition `yaml:"add_partitions,omitempty"`
+}
+
+type Device struct {
+	Label string `"yaml:label"`
+}
+
+type Expand struct {
+	Size uint `"yaml:size"`
+}
+
+type Partition struct {
+	FSLabel    string `yaml:"fsLabel"`
+	Size       uint   `yaml:"size,omitempty"`
+	PLabel     string `yaml:"pLabel,omitempty"`
+	FileSystem string `yaml:"filesystem,omitempty"`
+}
+
 type Stage struct {
 	Commands    []string    `yaml:"commands"`
 	Files       []File      `yaml:"files"`
@@ -98,6 +119,7 @@ type Stage struct {
 	EnvironmentFile string              `yaml:"environment_file"`
 
 	DataSources DataSource `yaml:"datasource"`
+	Layout      Layout     `yaml:"layout"`
 
 	SystemdFirstBoot map[string]string `yaml:"systemd_firstboot"`
 

--- a/tests/console/console_mock.go
+++ b/tests/console/console_mock.go
@@ -1,0 +1,84 @@
+package consoletests
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/hashicorp/go-multierror"
+	. "github.com/onsi/gomega"
+)
+
+type CmdMock struct {
+	Cmd    string
+	Output string
+}
+
+type TestConsoleMock struct {
+	Cmds *list.List
+}
+
+func New() *TestConsoleMock {
+	return &TestConsoleMock{Cmds: list.New()}
+}
+
+func (s TestConsoleMock) AddCmd(cmd CmdMock) {
+	s.Cmds.PushBack(&cmd)
+}
+
+func (s TestConsoleMock) AddCmds(cmds []CmdMock) {
+	for _, cmd := range cmds {
+		s.AddCmd(cmd)
+	}
+}
+
+func (s TestConsoleMock) PopCmd() *CmdMock {
+	e := s.Cmds.Front()
+	if e == nil {
+		return nil
+	}
+	s.Cmds.Remove(e)
+	cmdMock := e.Value.(*CmdMock)
+	return cmdMock
+}
+
+func (s TestConsoleMock) Run(cmd string, opts ...func(*exec.Cmd)) (string, error) {
+	cmdMock := s.PopCmd()
+	Expect(cmdMock).NotTo(BeNil())
+	if cmdMock.Cmd == cmd {
+		return cmdMock.Output, nil
+	} else {
+		Expect(cmd).To(Equal(cmdMock.Cmd))
+		return "", errors.New("Unexpected command")
+	}
+}
+
+func (s TestConsoleMock) Start(cmd *exec.Cmd, opts ...func(*exec.Cmd)) error {
+	cmdMock := s.PopCmd()
+	Expect(cmdMock).NotTo(BeNil())
+	cmdStr := strings.Join(cmd.Args[:], " ")
+	if cmdMock.Cmd == cmdStr {
+		return nil
+	} else {
+		Expect(cmdStr).To(Equal(cmdMock.Cmd))
+		return errors.New("Unexpected command")
+	}
+}
+
+func (s TestConsoleMock) RunTemplate(st []string, template string) error {
+	var errs error
+
+	for _, svc := range st {
+		out, err := s.Run(fmt.Sprintf(template, svc))
+		if err != nil {
+			log.Error(out)
+			log.Error(err.Error())
+			errs = multierror.Append(errs, err)
+			continue
+		}
+	}
+	return errs
+}


### PR DESCRIPTION
The Layout plugin mostly allows to expand the last partition to the disk
geometry and/or add additional partitions over the unpartitioned space.

In case there is no unpartitioned space on disk no changes are applied.

Fixes rancher-sandbox/cOS-toolkit#219

Signed-off-by: David Cassany <dcassany@suse.com>