### PR TITLE
Include authorized ssh keys management in user plugin

### DIFF
--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -137,6 +137,10 @@ func User(s schema.Stage, fs vfs.FS, console Console) error {
 				errs = multierror.Append(errs, err)
 			}
 		}
+
+		if len(p.SSHAuthorizedKeys) > 0 {
+			SSH(schema.Stage{SSHKeys: map[string][]string{p.Name: p.SSHAuthorizedKeys}}, fs, console)
+		}
 		/* 		else {
 			if err := setUserPassword(u, p.PasswordHash, console); err != nil {
 				errs = multierror.Append(errs, err)

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mudler/yip/pkg/schema"
 	consoletests "github.com/mudler/yip/tests/console"
 	"github.com/twpayne/go-vfs/vfst"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,7 +41,7 @@ var _ = Describe("User", func() {
 			defer cleanup()
 
 			err = User(schema.Stage{
-				Users: map[string]schema.User{"foo": {PasswordHash: `$fkekofe`, Homedir: "/home/foo"}},
+				Users: map[string]schema.User{"foo": {PasswordHash: `$fkekofe`, Homedir: "/home/foo", SSHAuthorizedKeys: []string{"github:mudler", "efafeeafea,t,t,pgl3,pbar"}}},
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -55,6 +56,13 @@ var _ = Describe("User", func() {
 
 			Expect(string(shadow)).Should(ContainSubstring("foo:$fkekofe:"))
 			Expect(string(passwd)).Should(Equal("foo:x:1000:1000::/home/foo:\n"))
+
+			file, err := fs.Open("/home/foo/.ssh/authorized_keys")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			b, err := ioutil.ReadAll(file)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(b)).Should(Equal("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDR9zjXvyzg1HFMC7RT4LgtR+YGstxWDPPRoAcNrAWjtQcJVrcVo4WLFnT0BMU5mtMxWSrulpC6yrwnt2TE3Ul86yMxO2hbSyGP/xOdYm/nQzufY49rd3tKeJl1+6DkczuPa+XYh1GBcW5E2laNM5ZK+RjABppMpDgmnrM3AsGNE6G8RSuUvc/6Rwt61ma+jak3F5YMj4kwr5PhY2MTPo2YshsL3ouRXP/uPsbaBM6AdQakjWGJR8tPbrnHenzF65813d9zuY4y78TG0AHfomx9btmha7Mc0YF+BpELnvSQLlYrlRY/ziGhP65aQc8lFMc+XBnHeaXF4NHnzq6dIH2D\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjWfZUB5W9HU70yOD1QW/7DSYZsisg8pPHnrxzS5WFnUvhnd7x3r9i+L8mRfk0tXk9p599e5uTryqaHW74bQK360+TnVens0JRF5vGeABe2L2GGrIkTIF8aTlPVq2BTDhu0R0rU28Cw3HwywX7cNjZdpFN2MtF74QbwqB0Ue7Nj6XxJjgV7GcecKEWc23Vjie6KEHlkFcgS0objZsiSt+hY3v3wJ94t+WZ8d1vEwvp7PX2J20W8Zq0bGcJiGMGuhDPRAZ4ju6HxIm60fUo9WzMNrZKVyEbMSYo6frLcmcMN0cDpDXE9WWnCwKDKnZEB0WqQcwOh1TQLYvRYEgMJair\n\nefafeeafea,t,t,pgl3,pbar\n"))
 		})
 	})
 })


### PR DESCRIPTION
This commit adds the SSH keys management within user creation.

Part of rancher-sandbox/cOS-toolkit#218