### PR TITLE
Create any missing parent directory for env files

### DIFF
--- a/pkg/plugins/environment.go
+++ b/pkg/plugins/environment.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/joho/godotenv"
 	"github.com/mudler/yip/pkg/schema"
@@ -11,6 +12,7 @@ import (
 )
 
 const environmentFile = "/etc/environment"
+const envFilePerm uint32 = 0644
 
 func Environment(s schema.Stage, fs vfs.FS, console Console) error {
 	if len(s.Environment) == 0 {
@@ -19,6 +21,27 @@ func Environment(s schema.Stage, fs vfs.FS, console Console) error {
 	environment := s.EnvironmentFile
 	if environment == "" {
 		environment = environmentFile
+	}
+
+	parentDir := filepath.Dir(environment)
+	_, err := fs.Stat(parentDir)
+	if err != nil {
+		perm := envFilePerm
+		if perm < 0700 {
+			perm = perm + 0100
+		}
+		if err = EnsureDirectories(schema.Stage{
+			Directories: []schema.Directory{
+				{
+					Path:        parentDir,
+					Permissions: perm,
+					Owner:       os.Getuid(),
+					Group:       os.Getgid(),
+				},
+			},
+		}, fs, console); err != nil {
+			return err
+		}
 	}
 
 	if err := utils.Touch(environment, os.ModePerm, fs); err != nil {
@@ -44,5 +67,5 @@ func Environment(s schema.Stage, fs vfs.FS, console Console) error {
 		return err
 	}
 
-	return fs.Chmod(environment, 0644)
+	return fs.Chmod(environment, os.FileMode(envFilePerm))
 }


### PR DESCRIPTION
This commit adds a check to verify parent directories for
environment files, if they do not exist they are created on the fly