### PR TITLE
Minor changes to userdata behavior

### DIFF
--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -148,6 +148,12 @@ func processSSHFile(fs vfs.FS, console Console) error {
 // If userdata can be parsed as a yipConfig file will create a <basePath>/userdata.yaml file
 func processUserData(basePath string, data []byte, fs vfs.FS, console Console) error {
 	dataS := string(data)
+
+	// always save unprocessed data to "userdata"
+	if err := writeToFile(path.Join(basePath, "userdata"), dataS, 0644, fs, console); err != nil {
+		return err
+	}
+
 	if _, err := schema.Load(dataS, fs, nil, nil); err == nil {
 		return writeToFile(path.Join(basePath, "userdata.yaml"), dataS, 0644, fs, console)
 	}
@@ -171,7 +177,7 @@ func processUserData(basePath string, data []byte, fs vfs.FS, console Console) e
 	}
 
 	log.Println("Could not unmarshall userdata and no shebang detected")
-	return writeToFile(path.Join(basePath, "userdata"), dataS, 0644, fs, console)
+	return nil
 }
 
 func writeToFile(filename string, content string, perm uint32, fs vfs.FS, console Console) error {

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -69,6 +69,10 @@ var _ = Describe("Schema", func() {
 	Context("Loading CloudConfig", func() {
 		It("Reads cloudconfig to boot stage", func() {
 			yipConfig := loadstdYip(`#cloud-config
+stages:
+  test:
+  - environment:
+      foo: bar
 users:
 - name: "bar"
   passwd: "foo"
@@ -87,12 +91,13 @@ write_files:
   permissions: "0644"
   owner: "bar"
 `)
-			Expect(len(yipConfig.Stages)).To(Equal(1))
+			Expect(len(yipConfig.Stages)).To(Equal(2))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
 			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"faaapploo", "asdd"}}))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
 			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal("bar"))
 			Expect(yipConfig.Stages["boot"][0].Commands).To(Equal([]string{"foo"}))
+			Expect(yipConfig.Stages["test"][0].Environment["foo"]).To(Equal("bar"))
 
 		})
 	})


### PR DESCRIPTION
* Always save raw userdata content to disk on boot
* Allow userdata to use both cloud-init and yip syntax at the same time 