### PR TITLE
Omit datasource plugin execution if providers list is empty

### DIFF
--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -19,7 +19,7 @@ import (
 func DataSources(s schema.Stage, fs vfs.FS, console Console) error {
 	var AvailableProviders = []prv.Provider{}
 
-	if s.DataSources.Providers == nil {
+	if s.DataSources.Providers == nil || len(s.DataSources.Providers) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
This commit fixes #17

Signed-off-by: David Cassany <dcassany@suse.com>