### PR TITLE
Add explicit references to devices by path

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -85,6 +85,7 @@ type Layout struct {
 
 type Device struct {
 	Label string `"yaml:label"`
+	Path  string `"yaml:path"`
 }
 
 type Expand struct {


### PR DESCRIPTION
This commit adds explicit references to devices by path. This allows to
point devices that might not have yet any partition table on them.

Related to rancher-sandbox/cOS-toolkit#411

Signed-off-by: David Cassany <dcassany@suse.com>