### PR TITLE
layout: Check for valid label on xfs systems

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -53,6 +53,11 @@ func Layout(s schema.Stage, fs vfs.FS, console Console) error {
 
 	var dev Disk
 	var err error
+	for _, l := range s.Layout.Parts {
+		if l.FileSystem == "xfs" && len(l.FSLabel) > 12 {
+			return errors.New(fmt.Sprintf("xfs filesystem %s cannot have a label longer than 12 chars", l.FSLabel))
+		}
+	}
 	if len(strings.TrimSpace(s.Layout.Device.Label)) > 0 {
 		dev, err = FindDiskFromPartitionLabel(s.Layout.Device.Label, console)
 		if err != nil {


### PR DESCRIPTION
xfs filesystems cannot have labels longer than 12 chars.

This patch adds a check at the start of the layout plugin before
touching the disk in order to check that the label is no longer than 12
characters if we are modifying an xfs partition.

Adds tests for it and the correct working of the check on non-xfs fs.

Also modifies the tests a bit so the mocking commands can be more
dynamic and sets vars for the deviceLabel and partition label so they
are all the same across all the tests.

Signed-off-by: Itxaka <igarcia@suse.com>