### PR TITLE
Handle the default case for ssh_authorized_keys in cloud-config

### DIFF
--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -68,6 +68,11 @@ func (cloudInit) Load(s []byte, fs vfs.FS) (*YipConfig, error) {
 		}
 	}
 
+	// If no users are defined, then assume global ssh_authorized_keys is assigned to root
+	if len(userstoKey) == 0 && len(cc.SSHAuthorizedKeys) > 0 {
+		sshKeys["root"] = cc.SSHAuthorizedKeys
+	}
+
 	// Decode writeFiles
 	var f []File
 	for _, ff := range cc.WriteFiles {


### PR DESCRIPTION
If no user is defined in cloud config, ssh_authorized_keys will be
assigned to the root user. The cloud config docs don't specifically
mention this use case, but this is the default behavior of cloud-init
that most users expect.