### PR TITLE
Fix write_files permissions and hostname

### DIFF
--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -94,11 +94,10 @@ func (cloudInit) Load(s []byte, fs vfs.FS) (*YipConfig, error) {
 	stages := []Stage{{
 		Commands: cc.RunCmd,
 		Files:    f,
-		Hostname: cc.Hostname,
 		Users:    users,
 		SSHKeys:  sshKeys,
 	}}
-	
+
 	for _, d := range cc.Partitioning.Devices {
 		layout := &Layout{}
 		layout.Expand = &Expand{Size: 0}
@@ -107,8 +106,13 @@ func (cloudInit) Load(s []byte, fs vfs.FS) (*YipConfig, error) {
 	}
 
 	result := &YipConfig{
-		Name:   "Cloud init",
-		Stages: map[string][]Stage{stage: stages},
+		Name: "Cloud init",
+		Stages: map[string][]Stage{
+			"boot": stages,
+			"initramfs": {{
+				Hostname: cc.Hostname,
+			}},
+		},
 	}
 
 	// optimistically load data as yip yaml

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -112,13 +112,14 @@ write_files:
   permissions: "0644"
   owner: "bar"
 `)
-			Expect(len(yipConfig.Stages)).To(Equal(2))
+			Expect(len(yipConfig.Stages)).To(Equal(3))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].UID).To(Equal("1002"))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
 			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"faaapploo", "asdd"}}))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
-			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal("bar"))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Permissions).To(Equal(uint32(0644)))
+			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal(""))
+			Expect(yipConfig.Stages["initramfs"][0].Hostname).To(Equal("bar"))
 			Expect(yipConfig.Stages["boot"][0].Commands).To(Equal([]string{"foo"}))
 			Expect(yipConfig.Stages["test"][0].Environment["foo"]).To(Equal("bar"))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].LockPasswd).To(Equal(true))

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -118,6 +118,7 @@ write_files:
 			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"faaapploo", "asdd"}}))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
 			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal("bar"))
+			Expect(yipConfig.Stages["boot"][0].Files[0].Permissions).To(Equal(uint32(0644)))
 			Expect(yipConfig.Stages["boot"][0].Commands).To(Equal([]string{"foo"}))
 			Expect(yipConfig.Stages["test"][0].Environment["foo"]).To(Equal("bar"))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].LockPasswd).To(Equal(true))


### PR DESCRIPTION
This change fixes a bug in which permissons from write_files is
always set to 0.

By setting hostname in the boot stage services have initialized with the
old hostname.  Specifically I hit an issue where avahi would start before
the hostname was setup so mdns was not working properly