### PR TITLE
Retry getting the partition on layout plugin

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -368,7 +368,7 @@ func (dev Disk) FindPartitionDevice(partNum int, console Console) (string, error
 	}
 	match := re.FindStringSubmatch(out)
 	if match == nil {
-		return "", errors.New(fmt.Sprintf("Could find partition device path for partition %d", partNum))
+		return "", errors.New(fmt.Sprintf("Could not find partition device path for partition %d", partNum))
 	}
 	return match[1], nil
 }

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -50,9 +50,9 @@ var CmdsAddPartByDevPath []console.CmdMock = append([]console.CmdMock{
 	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
 	{Cmd: "sgdisk -P -n=5:0:+2097152 -t=5:8300 /some/device"},
 	{Cmd: "sgdisk -n=5:0:+2097152 -t=5:8300 /some/device"}, pTable,
-	{Cmd: "partprobe /some/device"}, sync, lsblkTypes,
+	{Cmd: "blockdev --rereadpt /some/device"}, sync, lsblkTypes,
 	{Cmd: "mkfs.ext2 -L MYLABEL /some/device5"},
-	{Cmd: "partprobe /some/device"},
+	{Cmd: "blockdev --rereadpt /some/device"},
 	sync,
 	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
 })
@@ -77,7 +77,7 @@ var CmdsExpandPart []console.CmdMock = []console.CmdMock{
 	{Cmd: "blkid /some/device4 -s TYPE -o value", Output: "ext4"},
 	{Cmd: "e2fsck -fy /some/device4"},
 	{Cmd: "resize2fs /some/device4"}, pTable,
-	{Cmd: "partprobe /some/device"},
+	{Cmd: "blockdev --rereadpt /some/device"},
 	sync,
 }
 
@@ -94,7 +94,7 @@ var CmdsExpandPartXfs []console.CmdMock = []console.CmdMock{
 	{Cmd: "xfs_growfs /tmp/*", UseRegexp: true},
 	{Cmd: "umount /tmp/*", UseRegexp: true},
 	pTable,
-	{Cmd: "partprobe /some/device"},
+	{Cmd: "blockdev --rereadpt /some/device"},
 	sync,
 }
 
@@ -108,9 +108,9 @@ func CmdsAddPartByLabel(fs string) []console.CmdMock {
 		{Cmd: fmt.Sprintf("blkid -l --match-token LABEL=%s -o device", label)},
 		{Cmd: "sgdisk -P -n=5:0:+2097152 -t=5:8300 /some/device"},
 		{Cmd: "sgdisk -n=5:0:+2097152 -t=5:8300 /some/device"}, pTable,
-		{Cmd: "partprobe /some/device"}, sync, lsblkTypes,
+		{Cmd: "blockdev --rereadpt /some/device"}, sync, lsblkTypes,
 		{Cmd: fmt.Sprintf("mkfs.%s -L %s /some/device5", fs, label)},
-		{Cmd: "partprobe /some/device"},
+		{Cmd: "blockdev --rereadpt /some/device"},
 		sync,
 		{Cmd: fmt.Sprintf("blkid -l --match-token LABEL=%s -o device", label)},
 	}


### PR DESCRIPTION
Maybe the kernel doesnt have the partition table updated, so instead of
failing, we retry up to 5 times with a 1 second different between them
while calling the refresh on each iteration.

Also changes partprobe to blockdev as according to partprobe source, if
it cannot open a device it will exit with a 0 exit code, which can hide
real issues

Signed-off-by: Itxaka <igarcia@suse.com>