### PR TITLE
simplify FindPartitionDevice

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -357,20 +357,11 @@ func (dev Disk) ReloadPartitionTable(console Console) error {
 }
 
 func (dev Disk) FindPartitionDevice(partNum int, console Console) (string, error) {
-	out, err := console.Run(fmt.Sprintf("lsblk -ltnpo name,type %s", dev))
+	out, err := console.Run(fmt.Sprintf("lsblk -ltnpo name %s%d", dev.Device, partNum))
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("Could not list device partition nodes: %s", out))
+		return "", errors.New(fmt.Sprintf("Could not find in device %s partition number %d: %s", dev.Device, partNum, out))
 	}
-
-	re, err := regexp.Compile(fmt.Sprintf("(?m)^(/.*%d) part$", partNum))
-	if err != nil {
-		return "", errors.New("Failed compiling regexp")
-	}
-	match := re.FindStringSubmatch(out)
-	if match == nil {
-		return "", errors.New(fmt.Sprintf("Could not find partition device path for partition %d", partNum))
-	}
-	return match[1], nil
+	return strings.TrimSpace(out), nil
 }
 
 //Size is expressed in MiB here

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -31,11 +31,8 @@ Number  Start (sector)    End (sector)  Size       Code  Name
 }
 
 var lsblkTypes console.CmdMock = console.CmdMock{
-	Cmd: "lsblk -ltnpo name,type /some/device",
-	Output: `/some/device  disk
-/some/device1 part
-/some/device2 part
-/some/device5 part`,
+	Cmd: "lsblk -ltnpo name /some/device5",
+	Output: `/some/device5`,
 }
 
 var sync console.CmdMock = console.CmdMock{


### PR DESCRIPTION
Instead of listing everything and matching with regex we can directly
try to get the partition with lsblk and the full partition path.
If its not found it will return an error, otherwise it will return the
full partition path


This just covers a corner case in which we could have 2 partitions matching the same regex but the system only contains one, i.e. looking for partition `/dev/sda1` and that doesnt exists but partition `/dev/sda11` exists and that would match.

Also has a nice side effect of not using regex :P

Signed-off-by: Itxaka <igarcia@suse.com>