### PR TITLE
Update linuxkit fork dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220623141421-5afb4c282135 // indirect
 	github.com/apex/log v1.9.0
 	github.com/cavaliergopher/grab v2.0.0+incompatible
-	github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0
+	github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/diskfs/go-diskfs v1.2.1-0.20211109185859-9509735ba7a4 // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0 h1:daah7JMAXhtYXmde42h/e4tABt+BNj1UIMLeMqcq804=
 github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0/go.mod h1:GIS28BxE1G2YB+dCf+O2Ow/bVP7hqioSWLsvr9YQg3o=
+github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3 h1:HFmLFI+yemT7ckMZXXs8S7slTZs7Rc1kvNjXyfQ8IXE=
+github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3/go.mod h1:GIS28BxE1G2YB+dCf+O2Ow/bVP7hqioSWLsvr9YQg3o=
 github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
 github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/vendor/github.com/davidcassany/linuxkit/pkg/metadata/providers/provider_cdrom.go
+++ b/vendor/github.com/davidcassany/linuxkit/pkg/metadata/providers/provider_cdrom.go
@@ -86,6 +86,7 @@ func FindCIs() []string {
 		fs, err := disk.GetFilesystem(0)
 		if err != nil {
 			log.Debugf("failed to get filesystem on partition 0 for device: %s: %v", dev, err)
+			_ = disk.File.Close()
 			continue
 		}
 		// get the label
@@ -94,6 +95,10 @@ func FindCIs() []string {
 		if label == "cidata" || label == "CIDATA" {
 			log.Debugf("adding device: %s", dev)
 			foundDevices = append(foundDevices, dev)
+		}
+		err = disk.File.Close()
+		if err != nil {
+			log.Debugf("failed closing device %s", dev)
 		}
 	}
 	return foundDevices

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/apex/log
 # github.com/cavaliergopher/grab v2.0.0+incompatible
 ## explicit
 github.com/cavaliergopher/grab
-# github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0
+# github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3
 ## explicit
 github.com/davidcassany/linuxkit/pkg/metadata/providers
 # github.com/denisbrodbeck/machineid v1.0.1


### PR DESCRIPTION
This commit update linuxkit dependency to ensure datasource plugin
closes all block devices after probing them.

Signed-off-by: David Cassany <dcassany@suse.com>