### PR TITLE
Fix GO-2022-0244

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.7 // indirect
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0 h1:daah7JMAXhtYXmde42h/e4tABt+BNj1UIMLeMqcq804=
-github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220127113738-73e2e3a171a0/go.mod h1:GIS28BxE1G2YB+dCf+O2Ow/bVP7hqioSWLsvr9YQg3o=
 github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3 h1:HFmLFI+yemT7ckMZXXs8S7slTZs7Rc1kvNjXyfQ8IXE=
 github.com/davidcassany/linuxkit/pkg/metadata v0.0.0-20220725140037-b49d0fec13b3/go.mod h1:GIS28BxE1G2YB+dCf+O2Ow/bVP7hqioSWLsvr9YQg3o=
 github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
@@ -266,8 +264,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76 h1:ofyVTM1w4iyKwaQIlRR6Ip06mXXx5Cnz7a4mTGYq1hE=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/pkg/plugins/hostname.go
+++ b/pkg/plugins/hostname.go
@@ -31,7 +31,10 @@ func Hostname(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) er
 	rand.Seed(time.Now().UnixNano())
 
 	id, _ := machineid.ID()
-	myuuid := uuid.NewV4()
+	myuuid, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
 	tmpl, err := utils.TemplatedString(hostname,
 		struct {
 			UUID      string

--- a/vendor/github.com/satori/go.uuid/README.md
+++ b/vendor/github.com/satori/go.uuid/README.md
@@ -1,8 +1,8 @@
 # UUID package for Go language
 
-[![Build Status](https://travis-ci.org/satori/go.uuid.png?branch=master)](https://travis-ci.org/satori/go.uuid)
+[![Build Status](https://travis-ci.org/satori/go.uuid.svg?branch=master)](https://travis-ci.org/satori/go.uuid)
 [![Coverage Status](https://coveralls.io/repos/github/satori/go.uuid/badge.svg?branch=master)](https://coveralls.io/github/satori/go.uuid)
-[![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.png)](http://godoc.org/github.com/satori/go.uuid)
+[![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.svg)](http://godoc.org/github.com/satori/go.uuid)
 
 This package provides pure Go implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
 
@@ -37,13 +37,22 @@ import (
 
 func main() {
 	// Creating UUID Version 4
-	u1 := uuid.NewV4()
+	// panic on error
+	u1 := uuid.Must(uuid.NewV4())
 	fmt.Printf("UUIDv4: %s\n", u1)
+
+	// or error handling
+	u2, err := uuid.NewV4()
+	if err != nil {
+		fmt.Printf("Something went wrong: %s", err)
+		return
+	}
+	fmt.Printf("UUIDv4: %s\n", u2)
 
 	// Parsing UUID from string input
 	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	if err != nil {
-		fmt.Printf("Something gone wrong: %s", err)
+		fmt.Printf("Something went wrong: %s", err)
 	}
 	fmt.Printf("Successfully parsed: %s", u2)
 }

--- a/vendor/github.com/satori/go.uuid/generator.go
+++ b/vendor/github.com/satori/go.uuid/generator.go
@@ -26,7 +26,9 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/binary"
+	"fmt"
 	"hash"
+	"io"
 	"net"
 	"os"
 	"sync"
@@ -37,21 +39,23 @@ import (
 // UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
 const epochStart = 122192928000000000
 
-var (
-	global = newDefaultGenerator()
+type epochFunc func() time.Time
+type hwAddrFunc func() (net.HardwareAddr, error)
 
-	epochFunc = unixTimeFunc
-	posixUID  = uint32(os.Getuid())
-	posixGID  = uint32(os.Getgid())
+var (
+	global = newRFC4122Generator()
+
+	posixUID = uint32(os.Getuid())
+	posixGID = uint32(os.Getgid())
 )
 
 // NewV1 returns UUID based on current timestamp and MAC address.
-func NewV1() UUID {
+func NewV1() (UUID, error) {
 	return global.NewV1()
 }
 
 // NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func NewV2(domain byte) UUID {
+func NewV2(domain byte) (UUID, error) {
 	return global.NewV2(domain)
 }
 
@@ -61,7 +65,7 @@ func NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns random generated UUID.
-func NewV4() UUID {
+func NewV4() (UUID, error) {
 	return global.NewV4()
 }
 
@@ -72,74 +76,85 @@ func NewV5(ns UUID, name string) UUID {
 
 // Generator provides interface for generating UUIDs.
 type Generator interface {
-	NewV1() UUID
-	NewV2(domain byte) UUID
+	NewV1() (UUID, error)
+	NewV2(domain byte) (UUID, error)
 	NewV3(ns UUID, name string) UUID
-	NewV4() UUID
+	NewV4() (UUID, error)
 	NewV5(ns UUID, name string) UUID
 }
 
 // Default generator implementation.
-type generator struct {
-	storageOnce  sync.Once
-	storageMutex sync.Mutex
+type rfc4122Generator struct {
+	clockSequenceOnce sync.Once
+	hardwareAddrOnce  sync.Once
+	storageMutex      sync.Mutex
 
+	rand io.Reader
+
+	epochFunc     epochFunc
+	hwAddrFunc    hwAddrFunc
 	lastTime      uint64
 	clockSequence uint16
 	hardwareAddr  [6]byte
 }
 
-func newDefaultGenerator() Generator {
-	return &generator{}
+func newRFC4122Generator() Generator {
+	return &rfc4122Generator{
+		epochFunc:  time.Now,
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
 }
 
 // NewV1 returns UUID based on current timestamp and MAC address.
-func (g *generator) NewV1() UUID {
+func (g *rfc4122Generator) NewV1() (UUID, error) {
 	u := UUID{}
 
-	timeNow, clockSeq, hardwareAddr := g.getStorage()
-
+	timeNow, clockSeq, err := g.getClockSequence()
+	if err != nil {
+		return Nil, err
+	}
 	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
 	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
 	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
 	binary.BigEndian.PutUint16(u[8:], clockSeq)
 
+	hardwareAddr, err := g.getHardwareAddr()
+	if err != nil {
+		return Nil, err
+	}
 	copy(u[10:], hardwareAddr)
 
 	u.SetVersion(V1)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func (g *generator) NewV2(domain byte) UUID {
-	u := UUID{}
-
-	timeNow, clockSeq, hardwareAddr := g.getStorage()
+func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
+	u, err := g.NewV1()
+	if err != nil {
+		return Nil, err
+	}
 
 	switch domain {
 	case DomainPerson:
-		binary.BigEndian.PutUint32(u[0:], posixUID)
+		binary.BigEndian.PutUint32(u[:], posixUID)
 	case DomainGroup:
-		binary.BigEndian.PutUint32(u[0:], posixGID)
+		binary.BigEndian.PutUint32(u[:], posixGID)
 	}
 
-	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
-	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
-	binary.BigEndian.PutUint16(u[8:], clockSeq)
 	u[9] = domain
-
-	copy(u[10:], hardwareAddr)
 
 	u.SetVersion(V2)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV3 returns UUID based on MD5 hash of namespace UUID and name.
-func (g *generator) NewV3(ns UUID, name string) UUID {
+func (g *rfc4122Generator) NewV3(ns UUID, name string) UUID {
 	u := newFromHash(md5.New(), ns, name)
 	u.SetVersion(V3)
 	u.SetVariant(VariantRFC4122)
@@ -148,17 +163,19 @@ func (g *generator) NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns random generated UUID.
-func (g *generator) NewV4() UUID {
+func (g *rfc4122Generator) NewV4() (UUID, error) {
 	u := UUID{}
-	g.safeRandom(u[:])
+	if _, err := io.ReadFull(g.rand, u[:]); err != nil {
+		return Nil, err
+	}
 	u.SetVersion(V4)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
-func (g *generator) NewV5(ns UUID, name string) UUID {
+func (g *rfc4122Generator) NewV5(ns UUID, name string) UUID {
 	u := newFromHash(sha1.New(), ns, name)
 	u.SetVersion(V5)
 	u.SetVariant(VariantRFC4122)
@@ -166,66 +183,61 @@ func (g *generator) NewV5(ns UUID, name string) UUID {
 	return u
 }
 
-func (g *generator) initStorage() {
-	g.initClockSequence()
-	g.initHardwareAddr()
-}
-
-func (g *generator) initClockSequence() {
-	buf := make([]byte, 2)
-	g.safeRandom(buf)
-	g.clockSequence = binary.BigEndian.Uint16(buf)
-}
-
-func (g *generator) initHardwareAddr() {
-	interfaces, err := net.Interfaces()
-	if err == nil {
-		for _, iface := range interfaces {
-			if len(iface.HardwareAddr) >= 6 {
-				copy(g.hardwareAddr[:], iface.HardwareAddr)
-				return
-			}
+// Returns epoch and clock sequence.
+func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
+	var err error
+	g.clockSequenceOnce.Do(func() {
+		buf := make([]byte, 2)
+		if _, err = io.ReadFull(g.rand, buf); err != nil {
+			return
 		}
+		g.clockSequence = binary.BigEndian.Uint16(buf)
+	})
+	if err != nil {
+		return 0, 0, err
 	}
-
-	// Initialize hardwareAddr randomly in case
-	// of real network interfaces absence
-	g.safeRandom(g.hardwareAddr[:])
-
-	// Set multicast bit as recommended in RFC 4122
-	g.hardwareAddr[0] |= 0x01
-}
-
-func (g *generator) safeRandom(dest []byte) {
-	if _, err := rand.Read(dest); err != nil {
-		panic(err)
-	}
-}
-
-// Returns UUID v1/v2 storage state.
-// Returns epoch timestamp, clock sequence, and hardware address.
-func (g *generator) getStorage() (uint64, uint16, []byte) {
-	g.storageOnce.Do(g.initStorage)
 
 	g.storageMutex.Lock()
 	defer g.storageMutex.Unlock()
 
-	timeNow := epochFunc()
-	// Clock changed backwards since last UUID generation.
+	timeNow := g.getEpoch()
+	// Clock didn't change since last UUID generation.
 	// Should increase clock sequence.
 	if timeNow <= g.lastTime {
 		g.clockSequence++
 	}
 	g.lastTime = timeNow
 
-	return timeNow, g.clockSequence, g.hardwareAddr[:]
+	return timeNow, g.clockSequence, nil
+}
+
+// Returns hardware address.
+func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
+	var err error
+	g.hardwareAddrOnce.Do(func() {
+		if hwAddr, err := g.hwAddrFunc(); err == nil {
+			copy(g.hardwareAddr[:], hwAddr)
+			return
+		}
+
+		// Initialize hardwareAddr randomly in case
+		// of real network interfaces absence.
+		if _, err = io.ReadFull(g.rand, g.hardwareAddr[:]); err != nil {
+			return
+		}
+		// Set multicast bit as recommended by RFC 4122
+		g.hardwareAddr[0] |= 0x01
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+	return g.hardwareAddr[:], nil
 }
 
 // Returns difference in 100-nanosecond intervals between
 // UUID epoch (October 15, 1582) and current time.
-// This is default epoch calculation function.
-func unixTimeFunc() uint64 {
-	return epochStart + uint64(time.Now().UnixNano()/100)
+func (g *rfc4122Generator) getEpoch() uint64 {
+	return epochStart + uint64(g.epochFunc().UnixNano()/100)
 }
 
 // Returns UUID based on hashing of namespace UUID and name.
@@ -236,4 +248,18 @@ func newFromHash(h hash.Hash, ns UUID, name string) UUID {
 	copy(u[:], h.Sum(nil))
 
 	return u
+}
+
+// Returns hardware address.
+func defaultHWAddrFunc() (net.HardwareAddr, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []byte{}, err
+	}
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) >= 6 {
+			return iface.HardwareAddr, nil
+		}
+	}
+	return []byte{}, fmt.Errorf("uuid: no HW address found")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/pkg/errors
 # github.com/pkg/xattr v0.4.7
 ## explicit
 github.com/pkg/xattr
-# github.com/satori/go.uuid v1.2.0
+# github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 ## explicit
 github.com/satori/go.uuid
 # github.com/sergi/go-diff v1.2.0


### PR DESCRIPTION
Random data used to create UUIDs can contain zeros, resulting in predictable UUIDs and possible collisions.

Found in: github.com/satori/go.uuid@v1.2.0
Fixed in: github.com/satori/go.uuid@v1.2.1-0.20180404165556-75cca531ea76
More info: https://pkg.go.dev/vuln/GO-2022-0244

Signed-off-by: Itxaka <igarcia@suse.com>