### PR TITLE
Fix error message when "if" evaluation fails

### DIFF
--- a/pkg/plugins/if.go
+++ b/pkg/plugins/if.go
@@ -12,7 +12,7 @@ func IfConditional(l logger.Interface, s schema.Stage, fs vfs.FS, console Consol
 	if len(s.If) > 0 {
 		out, err := console.Run(templateSysData(l, s.If))
 		if err != nil {
-			return fmt.Errorf("Skipping stage (if statement didn't passed)")
+			return fmt.Errorf("Skipping stage (if statement error: %w)", err)
 		}
 		l.Debugf("If statement result %s", out)
 	}


### PR DESCRIPTION
This improves the log message when an `if` statement fails.


Example log output without this patch:
```
Error 'Skipping stage (if statement didn't passed)' in stage name: Recovery partition boot setup stage: rootfs.before
```

Example log output with this patch:
```
Error 'Skipping stage (if statement error: failed to run [ -n "$(blkid -L COS_SYSTEM || true)" ] || cat /proc/cmdline | grep -q "COS_RECOVERY"
: exit status 1)' in stage name: Recovery partition boot setup stage: rootfs.before
```

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>