### PR TITLE
Adds NetworkManager plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@ on: [push, pull_request]
 name: Build and Test
 jobs:
   test:
+    continue-on-error: true
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -579,3 +579,39 @@ stages:
              # default filesystem is ext2 if omitted
              filesystem: ext4
 ```
+
+
+### `stages.<stageID>.[<stepN>].NetworkManager`
+
+Configure NetworkManager `connection` files.
+It's a list of connections profiles, which support all NetworkManager config options by specifying the different sections on each profile.
+For example to use the `wifi` section we would create a `wifi` entry and specify the options as a list of key/value pairs.
+
+No uppercase and no dashes are allowed under the section names, if the section has a dash, its equivalent on the config yaml its removed (i.e. ip-tunnel section turns to iptunnel in the yaml) 
+
+Some sections are mapped under a different name due to constraints on golang naming conventions. These are as follows:
+
+| yaml name | NetworkManager section name |
+|-----------|-----------------------------|
+| x8021     | 802-1x                      |
+
+
+```yaml
+stages:
+  default:
+      - networkmanager:
+        - name: "Connection1"
+          Connection:
+            - interface-name: "wlan0"
+            - type: "wifi"
+          wifi:
+            - ssid: "testSSID"
+            - mode: "infrastructure"
+          wifisecurity:
+            - key-mgmt: "wpa-psk"
+            - psk: "123456789"
+          x8021:
+            - ca-path: "/path/ca.pem"
+```
+
+For a comprehensive list of all sections and their values check the [NetworkManager documentation](https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html)

--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -530,7 +530,6 @@ stages:
 
 			Expect(string(b)).Should(Equal("rootfs.before\nrootfs\n2\ninitramfs\n"))
 		})
-
 		It("has multiple instructions in different files", func() {
 			testConsole := console.NewStandardConsole()
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -91,6 +91,7 @@ func NewExecutor(opts ...Options) Executor {
 			plugins.SystemdFirstboot,
 			plugins.DataSources,
 			plugins.Layout,
+			plugins.NetworkManager,
 		},
 	}
 

--- a/pkg/plugins/networkmanager.go
+++ b/pkg/plugins/networkmanager.go
@@ -1,0 +1,66 @@
+//   Copyright 2022 Itxaka Serrano <itxakaserrano@gmail.com>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package plugins
+
+import (
+	"fmt"
+	"github.com/mudler/yip/pkg/logger"
+	"github.com/mudler/yip/pkg/schema"
+	"github.com/twpayne/go-vfs"
+	"gopkg.in/ini.v1"
+	"math/rand"
+	"path/filepath"
+)
+
+const ConnectionsDir = "/etc/NetworkManager/system-connections/"
+
+func NetworkManager(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
+	for _, conn := range s.NetworkManager {
+		cfg, err := conn.ToInifile()
+		if err != nil {
+			return err
+		}
+		if conn.Name == "" {
+			conn.Name = name(cfg)
+		}
+		finalFilePath := filepath.Join(ConnectionsDir, fmt.Sprintf("%s.connection", conn.Name))
+		l.Infof("Saving connection %s to file %s", conn.Name, finalFilePath)
+		f, err := fs.Create(finalFilePath)
+		if err != nil {
+			return err
+		}
+		_, err = cfg.WriteTo(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func name(cfg *ini.File) string {
+	if cfg.Section("connection").HasKey("id") {
+		// Connection has id, use that as name
+		return cfg.Section("connection").Key("id").String()
+	} else {
+		// No id, get the interface
+		iface := cfg.Section("connection").Key("interface-name")
+		// Get a random number of 4 digits. How absurd is this? Why isn't there a better interface to a random number in a range?
+		min := 1000
+		max := 9999
+		randomInt := rand.Intn(max-min+1) + min
+		return fmt.Sprintf("%s-%d", iface, randomInt)
+	}
+}

--- a/pkg/plugins/networkmanager_test.go
+++ b/pkg/plugins/networkmanager_test.go
@@ -1,0 +1,93 @@
+package plugins_test
+
+import (
+	"io"
+	"os"
+
+	"github.com/mudler/yip/pkg/executor"
+	"github.com/mudler/yip/pkg/schema"
+	consoletests "github.com/mudler/yip/tests/console"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs/vfst"
+	"gopkg.in/ini.v1"
+)
+
+var _ = Describe("NetworkManager", func() {
+	Context("connections", func() {
+		l := logrus.New()
+		l.SetOutput(io.Discard)
+		def := executor.NewExecutor(executor.WithLogger(l))
+		testConsole := consoletests.TestConsole{}
+		It("Creates connections", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/tmp/test/bar": ""})
+			Expect(err).Should(BeNil())
+			err = fs.Mkdir("/etc/", os.ModeDir|os.ModePerm)
+			Expect(err).Should(BeNil())
+			err = fs.Mkdir("/etc/NetworkManager/", os.ModeDir|os.ModePerm)
+			Expect(err).Should(BeNil())
+			err = fs.Mkdir("/etc/NetworkManager/system-connections/", os.ModeDir|os.ModePerm)
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			config := schema.YipConfig{
+				Stages: map[string][]schema.Stage{
+					"foo": []schema.Stage{{
+						NetworkManager: []schema.NetConnection{
+							{
+								Name: "test1",
+								Connection: []map[string]string{
+									{
+										"interface-name": "eth2",
+										"a":              "b",
+									},
+								},
+								Wifi: []map[string]string{
+									{
+										"ssid": "mySSID",
+									},
+								},
+								X8021: []map[string]string{
+									{
+										"key": "value",
+									},
+								},
+								Olpcmesh: []map[string]string{
+									{
+										"key": "value",
+									},
+								},
+							},
+							{
+								Name: "test2",
+							},
+						},
+					}}},
+			}
+			err = def.Apply("foo", config, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			file, err := fs.ReadFile("/etc/NetworkManager/system-connections/test1.connection")
+			Expect(err).ShouldNot(HaveOccurred())
+			// Load the written file
+			cfg, err := ini.Load(file)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cfg.HasSection("connection")).To(BeTrue())
+			Expect(cfg.HasSection("wifi")).To(BeTrue())
+			Expect(cfg.Section("connection").HasKey("interface-name")).To(BeTrue())
+			Expect(cfg.Section("connection").HasKey("a")).To(BeTrue())
+			Expect(cfg.Section("wifi").HasKey("ssid")).To(BeTrue())
+			Expect(cfg.Section("connection").Key("interface-name").Value()).To(Equal("eth2"))
+			Expect(cfg.Section("connection").Key("a").Value()).To(Equal("b"))
+			Expect(cfg.Section("wifi").Key("ssid").Value()).To(Equal("mySSID"))
+			// Special sections that are fully renamed
+			Expect(cfg.Section("802-1x").Key("key").Value()).To(Equal("value"))
+			Expect(cfg.Section("olpc-mesh").Key("key").Value()).To(Equal("value"))
+
+			file, err = fs.ReadFile("/etc/NetworkManager/system-connections/test2.connection")
+			Expect(err).ShouldNot(HaveOccurred())
+			cfg, err = ini.Load(file)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/plugins/timesyncd_test.go
+++ b/pkg/plugins/timesyncd_test.go
@@ -49,7 +49,10 @@ var _ = Describe("Timesyncd", func() {
 
 			b, err := ioutil.ReadAll(file)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(string(b)).Should(Equal("[Time]\nNTP = 0.pool\n"))
+			Expect(string(b)).Should(Or(
+				Equal("[Time]\nNTP = 0.pool\n"), // go 1.20
+				Equal("[Time]\nNTP=0.pool\n"),   // go 1.18/1.19
+			))
 		})
 	})
 })

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -150,6 +150,7 @@ type Stage struct {
 	Users           map[string]User     `yaml:"users,omitempty"`
 	Modules         []string            `yaml:"modules,omitempty"`
 	Systemctl       Systemctl           `yaml:"systemctl,omitempty"`
+	NetworkManager  []NetConnection     `yaml:"networkmanager,omitempty"`
 	Environment     map[string]string   `yaml:"environment,omitempty"`
 	EnvironmentFile string              `yaml:"environment_file,omitempty"`
 

--- a/pkg/schema/schema_networkmanager.go
+++ b/pkg/schema/schema_networkmanager.go
@@ -1,0 +1,145 @@
+//   Copyright 2022 Itxaka Serrano <itxakaserrano@gmail.com>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package schema
+
+import (
+	"github.com/google/uuid"
+	"gopkg.in/ini.v1"
+	"reflect"
+)
+
+type NetConnection struct {
+	// Name used to store the file, if empty then we try to use the connection id,
+	// if also empty use the connection type + interface
+	Name         string
+	Connection   []map[string]string
+	Wifi         []map[string]string
+	WifiSecurity []map[string]string
+	Ipv4         []map[string]string
+	Ipv6         []map[string]string
+	Proxy        []map[string]string
+	X8021        []map[string]string // Section name is 802-1x
+	Adsl         []map[string]string
+	Bluetooth    []map[string]string
+	Bond         []map[string]string
+	Bridge       []map[string]string
+	Bridgeport   []map[string]string // Section name is bridge-port
+	Cdma         []map[string]string
+	Dcb          []map[string]string
+	Ethtool      []map[string]string
+	Gsm          []map[string]string
+	Infiniband   []map[string]string
+	Iptunnel     []map[string]string // Section name is ip-tunnel
+	Macsec       []map[string]string
+	Macvlan      []map[string]string
+	Olpcmesh     []map[string]string // Section name is olpc-mesh or 802-11-olpc-mesh
+	Ovsbridge    []map[string]string // Section name is ovs-bridge
+	Ovsdpdk      []map[string]string // Section name is ovs-dpdk
+	Ovsinterface []map[string]string // Section name is ovs-interface
+	Ovspatch     []map[string]string // Section name is ovs-patch
+	Ovsport      []map[string]string // Section name is ovs-port
+	Ppp          []map[string]string
+	Pppoe        []map[string]string
+	Serial       []map[string]string
+	Sriov        []map[string]string
+	Tc           []map[string]string
+	Team         []map[string]string
+	Teamport     []map[string]string // Section name is team-port
+	Tun          []map[string]string
+	Vlan         []map[string]string
+	Vpn          []map[string]string
+	Vrf          []map[string]string
+	Vxlan        []map[string]string
+	Wifip2p      []map[string]string // Section name is wifi-p2p
+	Wimax        []map[string]string
+	Ethernet     []map[string]string
+	Wireguard    []map[string]string
+	Wpan         []map[string]string
+	Bondport     []map[string]string // Section name is bond-port
+	Hostname     []map[string]string
+	Veth         []map[string]string
+}
+
+// substitute contains the map to transform the valid struct fields into the valid section names
+// all section names are set to lower case by default with "gopkg.in/ini.v1" options
+var substitute = map[string]string{
+	"X8021":        "802-1x",
+	"Bridgeport":   "bridge-port",
+	"Iptunnel":     "ip-tunnel",
+	"Olpcmesh":     "olpc-mesh",
+	"Ovsbridge":    "ovs-bridge",
+	"Ovsdpdk":      "ovs-dpdk",
+	"Ovsinterface": "ovs-interface",
+	"Ovspatch":     "ovs-patch",
+	"Ovsport":      "ovs-port",
+	"Teamport":     "team-port",
+	"Wifip2p":      "wifi-p2p",
+	"Bondport":     "bond-port",
+}
+
+// ToInifile transforms a NetConnection struct into an ini file compatible with NetworkManager
+func (n NetConnection) ToInifile() (*ini.File, error) {
+	var err error
+	// Set PrettyFormat false to avoid adding spaces between key and value
+	ini.PrettyFormat = false
+	cfg := ini.Empty(ini.LoadOptions{
+		Insensitive:         true,
+		InsensitiveSections: true,
+		InsensitiveKeys:     true,
+	})
+
+	// Set unique uuid per connection
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+	_, err = cfg.Section("connection").NewKey("uuid", id.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Some workaround to reduce code in here
+	// reflect NetConnection
+	// iterate over the number of fields
+	// get the section name via the field name
+	// substitute the section name if needed (config names and golang names are not compatible)
+	// Check format of the field
+	// if map[string]string, get the values of the field as key,value and store it under that section
+	// This avoids having to iterate over each section manually
+	v := reflect.ValueOf(n)
+	v.NumField()
+	typeOfS := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		sectionName := typeOfS.Field(i).Name
+		// Check if we need to substitute the section name
+		if substitute[typeOfS.Field(i).Name] != "" {
+			sectionName = substitute[typeOfS.Field(i).Name]
+		}
+		switch values := v.Field(i).Interface().(type) {
+		case []map[string]string:
+			for _, kv := range values {
+				for key, value := range kv {
+					_, err = cfg.Section(sectionName).NewKey(key, value)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		default:
+			continue
+		}
+	}
+	return cfg, err
+}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -126,4 +126,53 @@ write_files:
 			Expect(yipConfig.Stages["boot"][1].Layout.Device.Path).To(Equal("/"))
 		})
 	})
+	Context("NetworkManager schema", func() {
+		It("Loads it correctly", func() {
+			yipConfig := loadstdYip(`
+stages:
+  default:
+    - networkmanager:
+      - name: "Connection1"
+        connection:
+          - interface-name: "wlan0"
+          - type: "wifi"
+        wifi:
+          - ssid: "testSSID"
+          - mode: "infrastructure"
+        wifisecurity:
+          - key-mgmt: "wpa-psk"
+          - psk: "123456789"
+      - name: "Connection2"
+        connection:
+          - interface-name: "wlan1"
+          - type: "wifi"
+        wifi:
+          - ssid: "testSSID"
+          - mode: "infrastructure"
+        wifisecurity:
+          - key-mgmt: "wpa-psk"
+          - psk: "123456789"
+        x8021:
+          - key: "value"
+        olpcmesh:
+          - key: "value"
+`)
+			// Should have 2 connections
+			Expect(len(yipConfig.Stages["default"][0].NetworkManager)).To(Equal(2))
+			// Check values
+			Expect(yipConfig.Stages["default"][0].NetworkManager[0].Name).To(Equal("Connection1"))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[1].Name).To(Equal("Connection2"))
+			Expect(len(yipConfig.Stages["default"][0].NetworkManager[0].Connection)).To(Equal(2))
+			Expect(len(yipConfig.Stages["default"][0].NetworkManager[1].Connection)).To(Equal(2))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[0].Connection).To(ContainElement(map[string]string{"interface-name": "wlan0"}))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[1].Connection).To(ContainElement(map[string]string{"interface-name": "wlan1"}))
+			Expect(len(yipConfig.Stages["default"][0].NetworkManager[0].Wifi)).To(Equal(2))
+			Expect(len(yipConfig.Stages["default"][0].NetworkManager[1].Wifi)).To(Equal(2))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[0].Wifi).To(ContainElement(map[string]string{"ssid": "testSSID"}))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[1].Wifi).To(ContainElement(map[string]string{"ssid": "testSSID"}))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[1].X8021).To(ContainElement(map[string]string{"key": "value"}))
+			Expect(yipConfig.Stages["default"][0].NetworkManager[1].Olpcmesh).To(ContainElement(map[string]string{"key": "value"}))
+
+		})
+	})
 })


### PR DESCRIPTION
Adds a NetworkManager plugin that writes the proper nm files into the /etc/NetworkManager/system-connections/ dir.

 - You can add more than one connection.
 - No validation whatsoever, other than generating a proper config file for NetworkManager. You are free to shoot yourself in the foot by adding weird key/values.
 - Supports all configuration sections

As NetworkManager supports like 400 different options, this plugin only make sure that the sections are valid, otherwise any key/values set in the sections are left to the user to check and configure properly based on NM docs.

Signed-off-by: Itxaka <igarcia@suse.com>