### PR TITLE
Execute stages in a dag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ import (
 var (
 	BuildTime   string
 	BuildCommit string
-	CLIVersion string
+	CLIVersion  string
 )
 
 func initLogger() logger.Interface {
@@ -69,6 +69,7 @@ For example:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stage, _ := cmd.Flags().GetString("stage")
 		dot, _ := cmd.Flags().GetBool("dotnotation")
+		analyze, _ := cmd.Flags().GetBool("analyze")
 
 		ll := initLogger()
 		runner := executor.NewExecutor(executor.WithLogger(ll))
@@ -93,6 +94,10 @@ For example:
 			args = []string{string(std)}
 		}
 
+		if analyze {
+			runner.Analyze(stage, vfs.OSFS, stdConsole, args...)
+			return nil
+		}
 		return runner.Run(stage, vfs.OSFS, stdConsole, args...)
 	},
 }
@@ -108,5 +113,6 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringP("stage", "s", "default", "Stage to apply")
+	rootCmd.PersistentFlags().BoolP("analyze", "a", false, "Analize execution graph")
 	rootCmd.PersistentFlags().BoolP("dotnotation", "d", false, "Parse input in dotnotation ( e.g. `stages.foo.name=..` ) ")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,12 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/moby/libnetwork v0.8.0-dev.2.0.20200612180813-9e99af28df21
 	github.com/mudler/entities v0.0.0-20220905203055-68348bae0f49
-	github.com/onsi/ginkgo/v2 v2.7.0
+	github.com/onsi/ginkgo/v2 v2.7.1
 	github.com/onsi/gomega v1.26.0
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/sirupsen/logrus v1.9.0
+	github.com/spectrocloud-labs/herd v0.3.0
 	github.com/spf13/cobra v1.5.0
 	github.com/twpayne/go-vfs v1.7.2
 	github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c
@@ -44,10 +45,7 @@ require (
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
@@ -56,6 +54,7 @@ require (
 	github.com/ishidawataru/sctp v0.0.0-20210707070123-9a39160e9062 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -76,8 +75,6 @@ require (
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
-	golang.org/x/tools v0.4.0 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/djherbis/times.v1 v1.3.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,9 +36,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/cavaliergopher/grab v2.0.0+incompatible h1:XLeGNAc7MIRTMb8RlRbN76uO8vx1/AeNMWWN7FYpDw8=
 github.com/cavaliergopher/grab v2.0.0+incompatible/go.mod h1:6ICNRTQPwkMP0m2sKIDv/9XkhFJJwiEOQyZ+8E4H7Yg=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -92,7 +89,6 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
@@ -111,9 +107,7 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -125,8 +119,6 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -147,7 +139,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
@@ -170,6 +161,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c h1:eKb4PqwAMhlqwXw0W3atpKaYaPGlXE/Fwh+xpCEYaPk=
+github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c/go.mod h1:VOfm8h1NySetVlpHDSnbpCMsvCgYaU+YDn4XezUy2+4=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
@@ -222,15 +215,13 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
 github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
-github.com/onsi/ginkgo/v2 v2.7.0 h1:/XxtEV3I3Eif/HobnVx9YmJgk8ENdRsuUmM+fLCFNow=
-github.com/onsi/ginkgo/v2 v2.7.0/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
+github.com/onsi/ginkgo/v2 v2.7.1 h1:YgLPk+gpqDtAPeRCWEmfO8oxE6ru3xcVSXAM7wn8w9I=
+github.com/onsi/ginkgo/v2 v2.7.1/go.mod h1:6JsQiECmxCa3V5st74AL/AmsV482EDdVrGaVW6z3oYU=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
-github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
-github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/packethost/packngo v0.1.0/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
@@ -288,6 +279,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spectrocloud-labs/herd v0.3.0 h1:n/VmHC/3NKfteYhiBonlFtohMRiMGuc6in0krqkyWMw=
+github.com/spectrocloud-labs/herd v0.3.0/go.mod h1:RHPSzrH+Jd05+ewEpqk8ZgBgTsnHN8erkxwRdQAiw3Q=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -401,7 +394,6 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200102141924-c96a22e43c9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -438,8 +430,6 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
-golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -454,10 +444,7 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -113,7 +113,7 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 			options: []herd.OpOption{herd.WeakDeps},
 		}
 
-		for _, d := range st.Depends {
+		for _, d := range st.After {
 			o.deps = append(o.deps, d.Name)
 		}
 

--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -62,7 +62,7 @@ func (e *DefaultExecutor) applyStage(stage schema.Stage, fs vfs.FS, console plug
 	var errs error
 	for _, p := range e.conditionals {
 		if err := p(e.logger, stage, fs, console); err != nil {
-			e.logger.Warnf("Skip '%s' stage name: %s\n",
+			e.logger.Warnf("(conditional) Skip '%s' stage name: %s\n",
 				err.Error(), stage.Name)
 			return nil
 		}
@@ -106,7 +106,7 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 		opName := fmt.Sprintf("%s.%s", rootname, name)
 		o := &op{
 			fn: func(ctx context.Context) error {
-				e.logger.Infof("Executing %s", file)
+				e.logger.Debugf("Reading %s", file)
 				return e.applyStage(st, fs, console)
 			},
 			name:    opName,

--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -97,12 +97,13 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 		if name == "" {
 			name = fmt.Sprint(i)
 		}
+
 		rootname := file
 		if config.Name != "" {
 			rootname = config.Name
 		}
 
-		opName := fmt.Sprintf("%s-%s-%s", rootname, stage, name)
+		opName := fmt.Sprintf("%s-%s", rootname, name)
 		o := &op{
 			fn: func(ctx context.Context) error {
 				e.logger.Infof("Executing %s", file)

--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -103,7 +103,7 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 			rootname = config.Name
 		}
 
-		opName := fmt.Sprintf("%s-%s", rootname, name)
+		opName := fmt.Sprintf("%s.%s", rootname, name)
 		o := &op{
 			fn: func(ctx context.Context) error {
 				e.logger.Infof("Executing %s", file)

--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -161,14 +161,16 @@ func (e *DefaultExecutor) dirOps(stage, dir string, fs vfs.FS, console plugins.C
 			ops := e.genOpFromSchema(path, stage, *config, fs, console)
 
 			// mark lexicographic order dependency from previous blocks
-			if len(prev) > 0 && len(ops) > 0 && len(ops[0].after) == 0 {
+			if len(prev) > 0 && len(ops) > 0 {
 				for _, p := range prev {
 					if len(p.after) == 0 {
 						all := []string{}
 						for _, pp := range prev {
 							all = append(all, pp.name)
 						}
-						ops[0].deps = append(ops[0].deps, all...)
+						for _, o := range ops {
+							o.deps = append(o.deps, all...)
+						}
 					}
 				}
 			}

--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -200,6 +200,58 @@ stages:
 
 		})
 
+		It("Run yip files in sequence with after", func() {
+			testConsole := console.NewStandardConsole()
+
+			fs2, cleanup2, err := vfst.NewTestFS(map[string]interface{}{})
+			Expect(err).Should(BeNil())
+			temp := fs2.TempDir()
+
+			defer cleanup2()
+
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/some/yip/01_first.yaml": `
+stages:
+  test:
+  - after: 
+    - name: "test.test"
+    commands:
+    - sed -i 's/bar/baz/g' ` + temp + `/tmp/test/bar
+`,
+				"/some/yip/02_second.yaml": `
+name: "test"
+stages:
+  test:
+  - name: "test"
+    commands:
+    - sed -i 's/boo/bar/g' ` + temp + `/tmp/test/bar
+`,
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = fs2.Mkdir("/tmp", os.ModePerm)
+			Expect(err).Should(BeNil())
+			err = fs2.Mkdir("/tmp/test", os.ModePerm)
+			Expect(err).Should(BeNil())
+
+			err = fs2.WriteFile("/tmp/test/bar", []byte(`boo`), os.ModePerm)
+			Expect(err).Should(BeNil())
+
+			err = def.Run("test", fs, testConsole, "/some/yip")
+			Expect(err).Should(BeNil())
+			file, err := os.Open(temp + "/tmp/test/bar")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			b, err := ioutil.ReadAll(file)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			Expect(string(b)).Should(Equal("baz"))
+
+		})
+
 		It("Execute single yip files", func() {
 			testConsole := console.NewStandardConsole()
 

--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -238,7 +238,7 @@ stages:
 				log.Fatal(err)
 			}
 
-			Expect(string(b)).Should(Equal("bar"))
+			Expect(string(b)).Should(Equal("bar"), string(b))
 		})
 
 		It("Reports error, and executes all yip files", func() {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mudler/yip/pkg/logger"
 	"github.com/mudler/yip/pkg/plugins"
 	"github.com/sirupsen/logrus"
-	"github.com/spectrocloud-labs/herd"
 	"github.com/twpayne/go-vfs"
 
 	"github.com/mudler/yip/pkg/schema"
@@ -65,7 +64,6 @@ func WithConditionals(p ...Plugin) Options {
 func NewExecutor(opts ...Options) Executor {
 	d := &DefaultExecutor{
 		logger: logrus.New(),
-		g:      herd.DAG(),
 		conditionals: []Plugin{
 			plugins.NodeConditional,
 			plugins.IfConditional,

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -65,7 +65,7 @@ func WithConditionals(p ...Plugin) Options {
 func NewExecutor(opts ...Options) Executor {
 	d := &DefaultExecutor{
 		logger: logrus.New(),
-		g:      herd.DAG(herd.EnableInit),
+		g:      herd.DAG(),
 		conditionals: []Plugin{
 			plugins.NodeConditional,
 			plugins.IfConditional,

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mudler/yip/pkg/logger"
 	"github.com/mudler/yip/pkg/plugins"
 	"github.com/sirupsen/logrus"
+	"github.com/spectrocloud-labs/herd"
 	"github.com/twpayne/go-vfs"
 
 	"github.com/mudler/yip/pkg/schema"
@@ -64,6 +65,7 @@ func WithConditionals(p ...Plugin) Options {
 func NewExecutor(opts ...Options) Executor {
 	d := &DefaultExecutor{
 		logger: logrus.New(),
+		g:      herd.DAG(herd.EnableInit),
 		conditionals: []Plugin{
 			plugins.NodeConditional,
 			plugins.IfConditional,

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -30,6 +30,7 @@ type Executor interface {
 	Plugins([]Plugin)
 	Conditionals([]Plugin)
 	Modifier(m schema.Modifier)
+	Analyze(string, vfs.FS, plugins.Console, ...string)
 }
 
 type Plugin func(logger.Interface, schema.Stage, vfs.FS, plugins.Console) error

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -153,7 +153,7 @@ type Stage struct {
 	Environment     map[string]string   `yaml:"environment,omitempty"`
 	EnvironmentFile string              `yaml:"environment_file,omitempty"`
 
-	Depends []Dependency `yaml:"depends,omitempty"`
+	After []Dependency `yaml:"after,omitempty"`
 
 	DataSources DataSource `yaml:"datasource,omitempty"`
 	Layout      Layout     `yaml:"layout,omitempty"`

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -128,6 +128,10 @@ type Partition struct {
 	FileSystem string `yaml:"filesystem,omitempty"`
 }
 
+type Dependency struct {
+	Name string `yaml:"name,omitempty"`
+}
+
 type Stage struct {
 	Commands    []string    `yaml:"commands,omitempty"`
 	Files       []File      `yaml:"files,omitempty"`
@@ -148,6 +152,8 @@ type Stage struct {
 	Systemctl       Systemctl           `yaml:"systemctl,omitempty"`
 	Environment     map[string]string   `yaml:"environment,omitempty"`
 	EnvironmentFile string              `yaml:"environment_file,omitempty"`
+
+	Depends []Dependency `yaml:"depends,omitempty"`
 
 	DataSources DataSource `yaml:"datasource,omitempty"`
 	Layout      Layout     `yaml:"layout,omitempty"`

--- a/vendor/github.com/kendru/darwin/go/depgraph/depgraph.go
+++ b/vendor/github.com/kendru/darwin/go/depgraph/depgraph.go
@@ -1,0 +1,232 @@
+package depgraph
+
+import (
+	"errors"
+)
+
+// A node in this graph is just a string, so a nodeset is a map whose
+// keys are the nodes that are present.
+type nodeset map[string]struct{}
+
+// depmap tracks the nodes that have some dependency relationship to
+// some other node, represented by the key of the map.
+type depmap map[string]nodeset
+
+type Graph struct {
+	nodes nodeset
+
+	// Maintain dependency relationships in both directions. These
+	// data structures are the edges of the graph.
+
+	// `dependencies` tracks child -> parents.
+	dependencies depmap
+	// `dependents` tracks parent -> children.
+	dependents depmap
+	// Keep track of the nodes of the graph themselves.
+}
+
+func New() *Graph {
+	return &Graph{
+		dependencies: make(depmap),
+		dependents:   make(depmap),
+		nodes:        make(nodeset),
+	}
+}
+
+func (g *Graph) DependOn(child, parent string) error {
+	if child == parent {
+		return errors.New("self-referential dependencies not allowed")
+	}
+
+	if g.DependsOn(parent, child) {
+		return errors.New("circular dependencies not allowed")
+	}
+
+	// Add nodes.
+	g.nodes[parent] = struct{}{}
+	g.nodes[child] = struct{}{}
+
+	// Add edges.
+	addNodeToNodeset(g.dependents, parent, child)
+	addNodeToNodeset(g.dependencies, child, parent)
+
+	return nil
+}
+
+func (g *Graph) DependsOn(child, parent string) bool {
+	deps := g.Dependencies(child)
+	_, ok := deps[parent]
+	return ok
+}
+
+func (g *Graph) HasDependent(parent, child string) bool {
+	deps := g.Dependents(parent)
+	_, ok := deps[child]
+	return ok
+}
+
+func (g *Graph) Leaves() []string {
+	leaves := make([]string, 0)
+
+	for node := range g.nodes {
+		if _, ok := g.dependencies[node]; !ok {
+			leaves = append(leaves, node)
+		}
+	}
+
+	return leaves
+}
+
+// TopoSortedLayers returns a slice of all of the graph nodes in topological sort order. That is,
+// if `B` depends on `A`, then `A` is guaranteed to come before `B` in the sorted output.
+// The graph is guaranteed to be cycle-free because cycles are detected while building the
+// graph. Additionally, the output is grouped into "layers", which are guaranteed to not have
+// any dependencies within each layer. This is useful, e.g. when building an execution plan for
+// some DAG, in which case each element within each layer could be executed in parallel. If you
+// do not need this layered property, use `Graph.TopoSorted()`, which flattens all elements.
+func (g *Graph) TopoSortedLayers() [][]string {
+	layers := [][]string{}
+
+	// Copy the graph
+	shrinkingGraph := g.clone()
+	for {
+		leaves := shrinkingGraph.Leaves()
+		if len(leaves) == 0 {
+			break
+		}
+
+		layers = append(layers, leaves)
+		for _, leafNode := range leaves {
+			shrinkingGraph.remove(leafNode)
+		}
+	}
+
+	return layers
+}
+
+func removeFromDepmap(dm depmap, key, node string) {
+	nodes := dm[key]
+	if len(nodes) == 1 {
+		// The only element in the nodeset must be `node`, so we
+		// can delete the entry entirely.
+		delete(dm, key)
+	} else {
+		// Otherwise, remove the single node from the nodeset.
+		delete(nodes, node)
+	}
+}
+
+func (g *Graph) remove(node string) {
+	// Remove edges from things that depend on `node`.
+	for dependent := range g.dependents[node] {
+		removeFromDepmap(g.dependencies, dependent, node)
+	}
+	delete(g.dependents, node)
+
+	// Remove all edges from node to the things it depends on.
+	for dependency := range g.dependencies[node] {
+		removeFromDepmap(g.dependents, dependency, node)
+	}
+	delete(g.dependencies, node)
+
+	// Finally, remove the node itself.
+	delete(g.nodes, node)
+}
+
+// TopoSorted returns all the nodes in the graph is topological sort order.
+// See also `Graph.TopoSortedLayers()`.
+func (g *Graph) TopoSorted() []string {
+	nodeCount := 0
+	layers := g.TopoSortedLayers()
+	for _, layer := range layers {
+		nodeCount += len(layer)
+	}
+
+	allNodes := make([]string, 0, nodeCount)
+	for _, layer := range layers {
+		for _, node := range layer {
+			allNodes = append(allNodes, node)
+		}
+	}
+
+	return allNodes
+}
+
+func (g *Graph) Dependencies(child string) nodeset {
+	return g.buildTransitive(child, g.immediateDependencies)
+}
+
+func (g *Graph) immediateDependencies(node string) nodeset {
+	return g.dependencies[node]
+}
+
+func (g *Graph) Dependents(parent string) nodeset {
+	return g.buildTransitive(parent, g.immediateDependents)
+}
+
+func (g *Graph) immediateDependents(node string) nodeset {
+	return g.dependents[node]
+}
+
+func (g *Graph) clone() *Graph {
+	return &Graph{
+		dependencies: copyDepmap(g.dependencies),
+		dependents:   copyDepmap(g.dependents),
+		nodes:        copyNodeset(g.nodes),
+	}
+}
+
+// buildTransitive starts at `root` and continues calling `nextFn` to keep discovering more nodes until
+// the graph cannot produce any more. It returns the set of all discovered nodes.
+func (g *Graph) buildTransitive(root string, nextFn func(string) nodeset) nodeset {
+	if _, ok := g.nodes[root]; !ok {
+		return nil
+	}
+
+	out := make(nodeset)
+	searchNext := []string{root}
+	for len(searchNext) > 0 {
+		// List of new nodes from this layer of the dependency graph. This is
+		// assigned to `searchNext` at the end of the outer "discovery" loop.
+		discovered := []string{}
+		for _, node := range searchNext {
+			// For each node to discover, find the next nodes.
+			for nextNode := range nextFn(node) {
+				// If we have not seen the node before, add it to the output as well
+				// as the list of nodes to traverse in the next iteration.
+				if _, ok := out[nextNode]; !ok {
+					out[nextNode] = struct{}{}
+					discovered = append(discovered, nextNode)
+				}
+			}
+		}
+		searchNext = discovered
+	}
+
+	return out
+}
+
+func copyNodeset(s nodeset) nodeset {
+	out := make(nodeset, len(s))
+	for k, v := range s {
+		out[k] = v
+	}
+	return out
+}
+
+func copyDepmap(m depmap) depmap {
+	out := make(depmap, len(m))
+	for k, v := range m {
+		out[k] = copyNodeset(v)
+	}
+	return out
+}
+
+func addNodeToNodeset(dm depmap, key, node string) {
+	nodes, ok := dm[key]
+	if !ok {
+		nodes = make(nodeset)
+		dm[key] = nodes
+	}
+	nodes[node] = struct{}{}
+}

--- a/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.7.1
+
+### Fixes
+- Bring back SuiteConfig.EmitSpecProgress to avoid compilation issue for consumers that set it manually [d2a1cb0]
+
+### Maintenance
+- Bump github.com/onsi/gomega from 1.24.2 to 1.25.0 (#1118) [cafece6]
+- Bump golang.org/x/tools from 0.4.0 to 0.5.0 (#1111) [eda66c2]
+- Bump golang.org/x/sys from 0.3.0 to 0.4.0 (#1112) [ac5ccaa]
+- Bump github.com/onsi/gomega from 1.24.1 to 1.24.2 (#1097) [eee6480]
+
 ## 2.7.0
 
 ### Features

--- a/vendor/github.com/onsi/ginkgo/v2/types/config.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/config.go
@@ -30,6 +30,7 @@ type SuiteConfig struct {
 	PollProgressAfter     time.Duration
 	PollProgressInterval  time.Duration
 	Timeout               time.Duration
+	EmitSpecProgress      bool // this is deprecated but its removal is causing compile issue for some users that were setting it manually
 	OutputInterceptorMode string
 	SourceRoots           []string
 	GracePeriod           time.Duration

--- a/vendor/github.com/onsi/ginkgo/v2/types/version.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/version.go
@@ -1,3 +1,3 @@
 package types
 
-const VERSION = "2.7.0"
+const VERSION = "2.7.1"

--- a/vendor/github.com/spectrocloud-labs/herd/.golangci.yml
+++ b/vendor/github.com/spectrocloud-labs/herd/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  timeout: 5m
+  tests: false
+linters:
+  enable:
+    - revive # replacement for golint
+    - dupl # check duplicated code
+    - goconst # check strings that can turn into constants
+    - gofmt # check fmt
+    - goheader # Check license headers, only checks files in current year
+    - goimports # check imports
+    - gocyclo # check complexity
+    - govet
+    - gosimple
+    - deadcode
+    - ineffassign
+    - unused
+    - varcheck
+    - staticcheck
+    - typecheck
+    - structcheck
+    - godot
+    - misspell

--- a/vendor/github.com/spectrocloud-labs/herd/Earthfile
+++ b/vendor/github.com/spectrocloud-labs/herd/Earthfile
@@ -1,0 +1,31 @@
+VERSION 0.6
+
+ARG GO_VERSION=1.18
+ARG GOLINT_VERSION=1.47.3
+
+go-deps:
+    ARG GO_VERSION
+    FROM golang:$GO_VERSION
+    WORKDIR /build
+    COPY go.mod go.sum ./
+    RUN go mod download
+    RUN apt-get update
+    SAVE ARTIFACT go.mod AS LOCAL go.mod
+    SAVE ARTIFACT go.sum AS LOCAL go.sum
+
+test:
+    FROM +go-deps
+    WORKDIR /build
+    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+    COPY . .
+    RUN ginkgo run --race --fail-fast --slow-spec-threshold 30s --covermode=atomic --coverprofile=coverage.out -p -r ./
+    SAVE ARTIFACT coverage.out AS LOCAL coverage.out
+
+lint:
+    ARG GO_VERSION
+    FROM golang:$GO_VERSION
+    ARG GOLINT_VERSION
+    RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$GOLINT_VERSION
+    WORKDIR /build
+    COPY . .
+    RUN golangci-lint run

--- a/vendor/github.com/spectrocloud-labs/herd/LICENSE
+++ b/vendor/github.com/spectrocloud-labs/herd/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ettore Di Giacinto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/spectrocloud-labs/herd/README.md
+++ b/vendor/github.com/spectrocloud-labs/herd/README.md
@@ -1,0 +1,53 @@
+# herd
+
+Herd is a Embedded Runnable DAG (H.E.R.D.). it aims to be a tiny library that allows to define arbitrary DAG, and associate job operations on them.
+
+## Why?
+
+I've found couple of nice libraries ([fx](https://github.com/uber-go/fx), or [dag](https://github.com/mostafa-asg/dag) for instance), however none of them satisfied my constraints:
+
+- Tiny
+- Completely tested (TDD)
+- Define jobs in a DAG, runs them in sequence, execute the ones that can be done in parallel (parallel topological sorting) in separate go routines
+- Provide some sorta of similarity with `systemd` concepts
+
+## Usage
+
+`herd` can be used as a library as such:
+
+```golang
+package main
+
+import (
+    "context"
+
+    "github.com/spectrocloud-labs/herd"
+)
+
+func main() {
+
+    // Generic usage
+    g := herd.DAG()
+    g.Add("name", ...)
+    g.Run(context.TODO())
+
+    // Example
+    f := ""
+    g.Add("foo", herd.WithCallback(func(ctx context.Context) error {
+        f += "foo"
+        // This executes after "bar" has ended successfully.
+        return nil
+    }), herd.WithDeps("bar"))
+
+    g.Add("bar", herd.WithCallback(func(ctx context.Context) error {
+        f += "bar"
+        // This execute first
+        return nil
+    }))
+
+    // Execute the DAG
+    g.Run(context.Background())
+    // f is "barfoo"
+}
+
+```

--- a/vendor/github.com/spectrocloud-labs/herd/dag.go
+++ b/vendor/github.com/spectrocloud-labs/herd/dag.go
@@ -1,0 +1,181 @@
+package herd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/kendru/darwin/go/depgraph"
+)
+
+// Graph represents a directed graph.
+type Graph struct {
+	*depgraph.Graph
+	ops            map[string]*OpState
+	init           bool
+	orphans        *sync.WaitGroup
+	collectOrphans bool
+}
+
+// GraphEntry is the external representation of
+// the operation to execute (OpState).
+type GraphEntry struct {
+	WithCallback    bool
+	Background      bool
+	Callback        []func(context.Context) error
+	Error           error
+	Fatal, WeakDeps bool
+	Name            string
+}
+
+// DAG creates a new instance of a runnable Graph.
+// A DAG is a Direct Acyclic Graph.
+// The graph is walked, and depending on the dependencies it will run the jobs as requested.
+// The Graph can be explored with `Analyze()`, extended with new operations with Add(),
+// and finally being run with Run(context.Context).
+func DAG(opts ...GraphOption) *Graph {
+	g := &Graph{Graph: depgraph.New(), ops: make(map[string]*OpState), orphans: &sync.WaitGroup{}}
+	for _, o := range opts {
+		o(g)
+	}
+	if g.init {
+		if err := g.Add("init"); err != nil {
+			return nil
+		}
+	}
+	return g
+}
+
+// Add adds a new operation to the graph.
+// Requires a name (string), and accepts a list of options.
+func (g *Graph) Add(name string, opts ...OpOption) error {
+	state := &OpState{Mutex: sync.Mutex{}}
+
+	for _, o := range opts {
+		if err := o(name, state, g); err != nil {
+			return err
+		}
+	}
+	g.ops[name] = state
+
+	if g.init && len(g.Graph.Dependents(name)) == 0 && name != "init" {
+		if err := g.Graph.DependOn(name, "init"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Stage returns the DAG item state.
+// Note: it locks to be thread-safe.
+func (g *Graph) State(name string) GraphEntry {
+	g.ops[name].Lock()
+	defer g.ops[name].Unlock()
+	return g.ops[name].toGraphEntry(name)
+}
+
+func (g *Graph) buildStateGraph() (graph [][]GraphEntry) {
+	for _, layer := range g.TopoSortedLayers() {
+		states := []GraphEntry{}
+
+		for _, r := range layer {
+			g.ops[r].Lock()
+			states = append(states, g.ops[r].toGraphEntry(r))
+			g.ops[r].Unlock()
+		}
+
+		graph = append(graph, states)
+	}
+	return
+}
+
+// Analyze returns the DAG and the Graph in the execution order.
+// It will also return eventual updates if called after Run().
+func (g *Graph) Analyze() (graph [][]GraphEntry) {
+	return g.buildStateGraph()
+}
+
+// Run starts the jobs defined in the DAG with a context.
+// It returns error in case of failure.
+func (g *Graph) Run(ctx context.Context) error {
+
+	checkFatal := func(layer []GraphEntry) error {
+		for _, s := range layer {
+			if s.Fatal && g.ops[s.Name].err != nil {
+				return g.ops[s.Name].err
+			}
+		}
+		return nil
+	}
+
+	for _, layer := range g.buildStateGraph() {
+		var wg sync.WaitGroup
+
+	LAYER:
+		for _, r := range layer {
+			if !r.WithCallback {
+				continue
+			}
+			fns := r.Callback
+
+			if !r.WeakDeps {
+				for k := range g.Graph.Dependencies(r.Name) {
+					g.ops[r.Name].Lock()
+					g.ops[k].Lock()
+
+					unlock := func() {
+						g.ops[r.Name].Unlock()
+						g.ops[k].Unlock()
+					}
+
+					if g.ops[k].err != nil {
+						g.ops[r.Name].err = fmt.Errorf("'%s' deps %s failed", r.Name, k)
+						unlock()
+
+						continue LAYER
+					}
+					unlock()
+				}
+			}
+
+			for i := range fns {
+				if !r.Background {
+					wg.Add(1)
+				} else if g.collectOrphans {
+					g.orphans.Add(1)
+				}
+
+				go func(ctx context.Context, g *Graph, key string, f func(context.Context) error) {
+					err := f(ctx)
+					g.ops[key].Lock()
+					if err != nil {
+						g.ops[key].err = multierror.Append(g.ops[key].err, err)
+					}
+					if !g.ops[key].background {
+						wg.Done()
+					} else if g.collectOrphans {
+						g.orphans.Done()
+					}
+					g.ops[key].Unlock()
+				}(ctx, g, r.Name, fns[i])
+			}
+		}
+
+		wg.Wait()
+		if err := checkFatal(layer); err != nil {
+			return err
+		}
+	}
+
+	if g.collectOrphans {
+		g.orphans.Wait()
+		for _, layer := range g.buildStateGraph() {
+			if err := checkFatal(layer); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/spectrocloud-labs/herd/dag_options.go
+++ b/vendor/github.com/spectrocloud-labs/herd/dag_options.go
@@ -1,0 +1,15 @@
+package herd
+
+// GraphOption it's the option for the DAG graph.
+type GraphOption func(g *Graph)
+
+// EnableInit enables an Init jobs that takes paternity
+// of orphan jobs without dependencies.
+var EnableInit GraphOption = func(g *Graph) {
+	g.init = true
+}
+
+// CollectOrphans enables orphan job collection.
+var CollectOrphans GraphOption = func(g *Graph) {
+	g.collectOrphans = true
+}

--- a/vendor/github.com/spectrocloud-labs/herd/ops.go
+++ b/vendor/github.com/spectrocloud-labs/herd/ops.go
@@ -1,0 +1,27 @@
+package herd
+
+import (
+	"context"
+	"sync"
+)
+
+type OpState struct {
+	sync.Mutex
+	fn         []func(context.Context) error
+	err        error
+	fatal      bool
+	background bool
+	weak       bool
+}
+
+func (o *OpState) toGraphEntry(name string) GraphEntry {
+	return GraphEntry{
+		WithCallback: o.fn != nil,
+		Callback:     o.fn,
+		Error:        o.err,
+		Background:   o.background,
+		WeakDeps:     o.weak,
+		Fatal:        o.fatal,
+		Name:         name,
+	}
+}

--- a/vendor/github.com/spectrocloud-labs/herd/ops_options.go
+++ b/vendor/github.com/spectrocloud-labs/herd/ops_options.go
@@ -1,0 +1,63 @@
+package herd
+
+import "context"
+
+// OpOption defines the operation settings.
+type OpOption func(string, *OpState, *Graph) error
+
+var NoOp OpOption = func(s string, os *OpState, g *Graph) error { return nil }
+
+// FatalOp makes the operation fatal.
+// Any error will make the DAG to stop and return the error immediately.
+var FatalOp OpOption = func(key string, os *OpState, g *Graph) error {
+	os.fatal = true
+	return nil
+}
+
+// Background runs the operation in the background.
+var Background OpOption = func(key string, os *OpState, g *Graph) error {
+	os.background = true
+	return nil
+}
+
+// WeakDeps sets the dependencies of the job as "weak".
+// Any failure of the jobs which depends on won't impact running the job.
+// By default, a failure job will make also fail all the children - this is option
+// disables this behavor and make the child start too.
+var WeakDeps OpOption = func(key string, os *OpState, g *Graph) error {
+	os.weak = true
+	return nil
+}
+
+// WithDeps defines an operation dependency.
+// Dependencies can be expressed as a string.
+// Note: before running the DAG you must define all the operations.
+func WithDeps(deps ...string) OpOption {
+	return func(key string, os *OpState, g *Graph) error {
+		for _, d := range deps {
+			if err := g.Graph.DependOn(key, d); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// ConditionalOption defines an option that is enabled only if the
+// conditional callback returns true.
+func ConditionalOption(condition func() bool, op OpOption) OpOption {
+	if condition() {
+		return op
+	}
+
+	return NoOp
+}
+
+// WithCallback associates a callback to the operation to be executed
+// when the DAG is walked-by.
+func WithCallback(fn ...func(context.Context) error) OpOption {
+	return func(s string, os *OpState, g *Graph) error {
+		os.fn = append(os.fn, fn...)
+		return nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,10 +135,6 @@ github.com/go-git/go-git/v5/utils/merkletrie/noder
 ## explicit; go 1.16
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
-# github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0
-## explicit; go 1.13
-# github.com/golang/protobuf v1.5.2
-## explicit; go 1.9
 # github.com/google/go-cmp v0.5.9
 ## explicit; go 1.13
 github.com/google/go-cmp/cmp
@@ -146,8 +142,6 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38
-## explicit; go 1.14
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 ## explicit; go 1.13
 github.com/google/shlex
@@ -184,6 +178,9 @@ github.com/jbenet/go-context/io
 # github.com/joho/godotenv v1.4.0
 ## explicit; go 1.12
 github.com/joho/godotenv
+# github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c
+## explicit; go 1.16
+github.com/kendru/darwin/go/depgraph
 # github.com/kevinburke/ssh_config v1.2.0
 ## explicit
 github.com/kevinburke/ssh_config
@@ -202,7 +199,7 @@ github.com/moby/libnetwork/resolvconf
 # github.com/mudler/entities v0.0.0-20220905203055-68348bae0f49
 ## explicit; go 1.12
 github.com/mudler/entities/pkg/entities
-# github.com/onsi/ginkgo/v2 v2.7.0
+# github.com/onsi/ginkgo/v2 v2.7.1
 ## explicit; go 1.18
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config
@@ -254,6 +251,9 @@ github.com/shopspring/decimal
 # github.com/sirupsen/logrus v1.9.0
 ## explicit; go 1.13
 github.com/sirupsen/logrus
+# github.com/spectrocloud-labs/herd v0.3.0
+## explicit; go 1.19
+github.com/spectrocloud-labs/herd
 # github.com/spf13/cast v1.5.0
 ## explicit; go 1.18
 github.com/spf13/cast
@@ -347,10 +347,6 @@ golang.org/x/text/internal/utf8internal
 golang.org/x/text/language
 golang.org/x/text/runes
 golang.org/x/text/transform
-# golang.org/x/tools v0.4.0
-## explicit; go 1.18
-# google.golang.org/protobuf v1.28.0
-## explicit; go 1.11
 # gopkg.in/djherbis/times.v1 v1.3.0
 ## explicit
 gopkg.in/djherbis/times.v1


### PR DESCRIPTION
This changes enhances the `yip` execution flow such as now allows introspection.

The PR changes the inner logic of the executor to just generate operations. The operations are loaded into a DAG which is executed.  

- A new flag `--analyze` is introduced, can be used as such to print the execution dag of a set of cloud config:

```
❯ ./yip -s network --analyze ~/_git/kairos/examples                                                                                                                                                                                                              
INFO[0000] 1.                                                                                            
INFO[0000]  <init> (background: false) (weak: false)     
INFO[0000] 2.                                            
INFO[0000]  <Default deployment-network-Setup k3s> (background: false) (weak: true)                                                                                                                                
INFO[0000] 3.                                                                            
INFO[0000]  <Default deployment-network-1> (background: false) (weak: true) 
```
- A new field `after` is available in the stages to allow nested dependencies in the same stage, across different files by refering to it with the name of yip file and the block concatenated by a `.` (note this is not allowing dependencies from different stages!):

_file 1_
```yaml
stages:
 rootfs:
 - after:
   - name: foo.action
```

_file 2_
```yaml
name: "foo"
stages:
  rootfs:
  - name: "action"
```
