### PR TITLE
Name executor operations based on schema structure

### DIFF
--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -94,11 +94,6 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 
 	prev := ""
 	for i, st := range currentStages {
-		name := st.Name
-		if name == "" {
-			name = fmt.Sprint(i)
-		}
-
 		rootname := file
 		if config.Name != "" {
 			rootname = config.Name
@@ -106,7 +101,7 @@ func (e *DefaultExecutor) genOpFromSchema(file, stage string, config schema.YipC
 
 		// Copy here so it doesn't get overwritten and points to the same state
 		stageLocal := st
-		opName := fmt.Sprintf("%s.%s", rootname, name)
+		opName := fmt.Sprintf("%s.%s.step-%d", rootname, stage, i)
 
 		e.logger.Debugf("Generating op for stage '%s'", opName)
 		o := &op{

--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -217,7 +217,7 @@ stages:
 stages:
   test:
   - after: 
-    - name: "test.test"
+    - name: "test.test.step-0"
     commands:
     - sed -i 's/bar/baz/g' ` + temp + `/tmp/test/bar
 `,
@@ -596,18 +596,18 @@ stages:
 			Expect(len(g)).To(Equal(3), fmt.Sprintf("%+v", g))
 			Expect(len(g[1])).To(Equal(1))
 			Expect(len(g[2])).To(Equal(1))
-			Expect(g[1][0].Name).To(Equal("Rootfs Layout Settings.before roots"))
-			Expect(g[2][0].Name).To(Equal("second Rootfs Layout Settings.second before roots"))
+			Expect(g[1][0].Name).To(Equal("Rootfs Layout Settings.rootfs.before.step-0"))
+			Expect(g[2][0].Name).To(Equal("second Rootfs Layout Settings.rootfs.before.step-0"))
 
 			g1, err := def.Graph("rootfs", fs, testConsole, "/some/yip")
 			Expect(err).Should(BeNil())
 			Expect(len(g1)).To(Equal(5), fmt.Sprintf("%+v", g1))
 			Expect(len(g1[1])).To(Equal(1))
 			Expect(len(g1[2])).To(Equal(1))
-			Expect(g1[1][0].Name).To(Equal("Rootfs Layout Settings.rootfs"))
-			Expect(g1[2][0].Name).To(Equal("Rootfs Layout Settings.rootfs 2"))
-			Expect(g1[3][0].Name).To(Equal("second Rootfs Layout Settings.second rootfs"))
-			Expect(g1[4][0].Name).To(Equal("second Rootfs Layout Settings.second rootfs 2"))
+			Expect(g1[1][0].Name).To(Equal("Rootfs Layout Settings.rootfs.step-0"))
+			Expect(g1[2][0].Name).To(Equal("Rootfs Layout Settings.rootfs.step-1"))
+			Expect(g1[3][0].Name).To(Equal("second Rootfs Layout Settings.rootfs.step-0"))
+			Expect(g1[4][0].Name).To(Equal("second Rootfs Layout Settings.rootfs.step-1"))
 
 			err = def.Run("rootfs.before", fs, testConsole, "/some/yip")
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
This PR changes the naming convention of the default executor operations. Prevents using the name of the step and uses schema index instead. Using the user provided step name does not guarantee the resulting op name is unique, hence steps having the same name are silently overwriting each other.

The issue can be easily reproduced with the following schema:

```yaml
name: "This is a test"
stages:
  teststage:
  - name: "notUnique"
    commands:
    - echo "ONE"
  - name: "notUnique"
    commands:
    - echo "TWO"
```

I guess there could be many other naming conventions, I just opted for this trying to prevent very long names. The `name` step in schema could be as long as a sentence and felt odd to me using it, as it will later on be a key in a map.