### PR TITLE
Expand last partition after creating the partitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
           go-version-file: 'go.mod'
       - name: Test
         run: make test
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -583,6 +583,9 @@ func (gd GdiskCall) GetLastSector(printOut string) (uint, error) {
 }
 
 // Parses the output of a GdiskCall.Print call
+// There was a change in the output of sgdisk in version 1.0.2
+// https://www.rodsbooks.com/gdisk/revisions.html
+// We are trying to match both possible outputs
 func (gd GdiskCall) GetSectorSize(printOut string) (uint, error) {
 
 	// Matching: "Logical sector size: 512 bytes"
@@ -594,7 +597,6 @@ func (gd GdiskCall) GetSectorSize(printOut string) (uint, error) {
 	}
 
 	// Matching: "Sector size (logical/physical): 512/512 bytes"
-	// TODO: Why are there 2 different possible outputs from `sgdisk -p` ?
 	re = regexp.MustCompile(`Sector size \(logical\/physical\): (\d+)\/\d+ bytes`)
 	match = re.FindStringSubmatch(printOut)
 	if match != nil {

--- a/tests/console/console_mock.go
+++ b/tests/console/console_mock.go
@@ -14,8 +14,8 @@ import (
 )
 
 type CmdMock struct {
-	Cmd    string
-	Output string
+	Cmd       string
+	Output    string
 	UseRegexp bool
 }
 


### PR DESCRIPTION
We applied the same fix here:

https://github.com/kairos-io/kairos-agent/pull/32/files#diff-9bf4494bcc865684d4aeae7837925b1732855e863067c12a61f6f38e2fc16716

but we now want to use the yip implementation everywhere:

- kairos-agent (see link above)
- immucore: https://github.com/kairos-io/immucore/blob/0811f0f054b086708727a441988d3e93905838a1/internal/utils/layout_plugin.go#L18