### PR TITLE
Only run unique datasources + parallel datasource adquisition + tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
-	github.com/rancher-sandbox/linuxkit v1.0.0
+	github.com/rancher-sandbox/linuxkit v1.0.1-0.20230517173613-432a87ba3e09
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spectrocloud-labs/herd v0.4.2
@@ -64,6 +64,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/samber/lo v1.37.0 // indirect
+	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -234,6 +235,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/xattr v0.4.1/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnFs=
 github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
 github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -247,6 +249,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rancher-sandbox/linuxkit v1.0.0 h1:ejEKyLWfByMkwzpmcSQLc5/RL3FtiKRpIgY+TUjFpaM=
 github.com/rancher-sandbox/linuxkit v1.0.0/go.mod h1:n6Fkjc5qoMeWrnLSA5oqUF8ZzFKMrM960CtBwfvH1ZM=
+github.com/rancher-sandbox/linuxkit v1.0.1-0.20230517173613-432a87ba3e09 h1:/yNp//3ZC5J7KUaUPDmomQ78j8VUD/2T/uT+TvS4M0w=
+github.com/rancher-sandbox/linuxkit v1.0.1-0.20230517173613-432a87ba3e09/go.mod h1:n6Fkjc5qoMeWrnLSA5oqUF8ZzFKMrM960CtBwfvH1ZM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
@@ -254,6 +258,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
 github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
+github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
+github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -293,6 +299,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -16,14 +16,32 @@ import (
 	"github.com/twpayne/go-vfs"
 )
 
+func unique(stringSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+
+	// If the key(values of the slice) is not equal
+	// to the already present value in new slice (list)
+	// then we append it. else we jump on another element.
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
 func DataSources(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
 	var AvailableProviders = []prv.Provider{}
 
 	if s.DataSources.Providers == nil || len(s.DataSources.Providers) == 0 {
 		return nil
 	}
+	// Avoid duplication
+	uniqueProviders := unique(s.DataSources.Providers)
 
-	for _, dSProviders := range s.DataSources.Providers {
+	for _, dSProviders := range uniqueProviders {
 		switch {
 		case dSProviders == "aws":
 			AvailableProviders = append(AvailableProviders, prv.NewAWS())

--- a/pkg/plugins/datasource_test.go
+++ b/pkg/plugins/datasource_test.go
@@ -1,0 +1,82 @@
+//   Copyright 2023 Ettore Di Giacinto <mudler@mocaccino.org>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package plugins_test
+
+import (
+	. "github.com/mudler/yip/pkg/plugins"
+	"github.com/mudler/yip/pkg/schema"
+	consoletests "github.com/mudler/yip/tests/console"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/linuxkit/providers"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs/vfst"
+	"strings"
+	"time"
+)
+
+var _ = Describe("Datasources", func() {
+	Context("running", func() {
+		testConsole := consoletests.TestConsole{}
+		l := logrus.New()
+		l.SetLevel(logrus.DebugLevel)
+		//l.SetOutput(io.Discard)
+		It("Runs datasources and fails to ", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+			err = DataSources(l, schema.Stage{
+				DataSources: schema.DataSource{
+					Providers: []string{"cdrom"},
+				},
+			}, fs, testConsole)
+			Expect(err).To(HaveOccurred())
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
+			_, err = fs.Stat(providers.ConfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Runs each datasource just once", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+			prv := []string{"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws",
+				"aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws", "aws"}
+			start := time.Now()
+			err = DataSources(l, schema.Stage{
+				DataSources: schema.DataSource{
+					Providers: prv,
+				},
+			}, fs, testConsole)
+			elapsed := time.Since(start)
+			Expect(err).To(HaveOccurred())
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
+			// check if it took less than 10 seconds. If we were to run all those datasources one after the other
+			// it would take much more
+			Expect(elapsed).To(BeNumerically("<", 10*time.Second))
+			_, err = fs.Stat(providers.ConfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Currently if you duplicate the datasources it would just keep adding
them to the list and running them one after the other wastinga lot of
time.

This patch just makes the datasources list unique before going over it.

Also makes metadata adquisition faster by running them in goroutines and then waiting for the
results to come back rather than running them in serial which can take a
long time for a large list of providers (providers * 2s timeout)

Also adds tests to the datasources.

Signed-off-by: Itxaka <itxaka.garcia@spectrocloud.com>