### PR TITLE
Add support for non GPT partition tables

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -351,11 +351,11 @@ func (dev *Disk) AddPartition(l logger.Interface, label string, size uint, fileS
 
 	gd.CreatePartition(&part)
 
-	isGPT, _ := dev.IsGPT(console)
-	// if err != nil {
-	// 	l.Errorf("Failed to determine partition table type: \n%s", err)
-	// 	return 0, err
-	// }
+	isGPT, err := dev.IsGPT(console)
+	if err != nil {
+		l.Errorf("Failed to determine partition table type: \n%s", err)
+		return "", err
+	}
 	out, err := gd.WriteChanges(console, !isGPT)
 	if err != nil {
 		return out, err
@@ -478,11 +478,11 @@ func (dev *Disk) ExpandLastPartition(l logger.Interface, size uint, console Cons
 
 	gd.DeletePartition(part.Number)
 	gd.CreatePartition(&part)
-	isGPT, _ := dev.IsGPT(console)
-	// if err != nil {
-	// 	l.Errorf("Failed to determine partition table type: \n%s", err)
-	// 	return 0, err
-	// }
+	isGPT, err := dev.IsGPT(console)
+	if err != nil {
+		l.Errorf("Failed to determine partition table type: \n%s", err)
+		return "", err
+	}
 	out, err := gd.WriteChanges(console, !isGPT)
 	if err != nil {
 		return "", err

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -208,12 +208,12 @@ func (dev Disk) String() string {
 
 // IsGPT returns true if the disk is GPT partitioned
 func (dev *Disk) IsGPT(console Console) (bool, error) {
-	out, err := console.Run(fmt.Sprintf("fdisk -l %s", dev.Device))
+	out, err := console.Run(fmt.Sprintf("blkid %s -s PTTYPE -o value", dev.Device))
 	if err != nil {
 		return false, err
 	}
 
-	return strings.Contains(out, "Disklabel type: gpt"), nil
+	return strings.Contains(out, "gpt"), nil
 }
 
 func (dev *Disk) Reload(console Console) error {

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -35,7 +35,6 @@ type Partition struct {
 
 type GdiskCall struct {
 	disk      *Disk
-	dev       string
 	wipe      bool
 	parts     []*Partition
 	deletions []int
@@ -537,7 +536,7 @@ func (dev Disk) expandFilesystem(device string, console Console) (string, error)
 }
 
 func NewGdiskCall(disk *Disk) *GdiskCall {
-	return &GdiskCall{disk: disk, dev: disk.String(), wipe: false, parts: []*Partition{}, deletions: []int{}, expand: false, pretend: false, forceGPT: false}
+	return &GdiskCall{disk: disk, wipe: false, parts: []*Partition{}, deletions: []int{}, expand: false, pretend: false, forceGPT: false}
 }
 
 func (gd GdiskCall) buildOptions() []string {
@@ -579,12 +578,17 @@ func (gd GdiskCall) buildOptions() []string {
 		return nil
 	}
 
-	opts = append(opts, gd.dev)
+	opts = append(opts, gd.Device())
 	return opts
 }
 
+// Device returns the associated path of the disk in a GdiskCall.
+func (gd GdiskCall) Device() string {
+	return gd.disk.String()
+}
+
 func (gd GdiskCall) Verify(console Console) (string, error) {
-	return console.Run(fmt.Sprintf("sgdisk --verify %s", gd.dev))
+	return console.Run(fmt.Sprintf("sgdisk --verify %s", gd.Device()))
 }
 
 func (gd GdiskCall) HasUnallocatedSpace(console Console) bool {
@@ -596,11 +600,11 @@ func (gd GdiskCall) HasUnallocatedSpace(console Console) bool {
 }
 
 func (gd GdiskCall) Print(console Console) (string, error) {
-	return console.Run(fmt.Sprintf("sgdisk -p %s", gd.dev))
+	return console.Run(fmt.Sprintf("sgdisk -p %s", gd.Device()))
 }
 
 func (gd GdiskCall) Info(partNum int, console Console) (string, error) {
-	return console.Run(fmt.Sprintf("sgdisk -i %d %s", partNum, gd.dev))
+	return console.Run(fmt.Sprintf("sgdisk -i %d %s", partNum, gd.Device()))
 }
 
 // Parses the output of a GdiskCall.Print call

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -97,12 +97,12 @@ var sync console.CmdMock = console.CmdMock{
 var CmdsAddPartByDevPath []console.CmdMock = []console.CmdMock{
 	{Cmd: "lsblk -npo type /some/device", Output: "loop"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -e /some/device"},
 	{Cmd: "sgdisk -e /some/device"}, pTable,
 	{Cmd: "udevadm settle"},
 	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -n=5:0:+2097152 -t=5:8300 /some/device"},
 	{Cmd: "sgdisk -n=5:0:+2097152 -t=5:8300 /some/device"}, pTable,
 	{Cmd: "udevadm settle"},
@@ -122,31 +122,21 @@ var CmdsAddAlreadyExistingPart []console.CmdMock = []console.CmdMock{
 	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
 	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -e /some/device"},
 	{Cmd: "sgdisk -e /some/device"}, pTable,
 	{Cmd: "udevadm settle"},
 	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device", Output: "/some/part"},
 }
 
-var fdiskListGPT console.CmdMock = console.CmdMock{
-	Cmd: "fdisk -l /some/device",
-	Output: `Disk /dev/mmcblk0: 29.19 GiB, 31347703808 bytes, 61225984 sectors
-Units: sectors of 1 * 512 = 512 bytes
-Sector size (logical/physical): 512 bytes / 512 bytes
-I/O size (minimum/optimal): 512 bytes / 512 bytes
-Disklabel type: gpt
-Disk identifier: 0D58887C-F502-472A-8B86-9FD1B501A5A1`,
+var blkidGPT console.CmdMock = console.CmdMock{
+	Cmd:    "blkid /some/device -s PTTYPE -o value",
+	Output: "gpt\n",
 }
 
-var fdiskListMBR console.CmdMock = console.CmdMock{
-	Cmd: "fdisk -l /some/device",
-	Output: `Disk /dev/mmcblk0: 29.19 GiB, 31347703808 bytes, 61225984 sectors
-Units: sectors of 1 * 512 = 512 bytes
-Sector size (logical/physical): 512 bytes / 512 bytes
-I/O size (minimum/optimal): 512 bytes / 512 bytes
-Disklabel type: dos
-Disk identifier: 0D58887C-F502-472A-8B86-9FD1B501A5A1`,
+var blkidMBR console.CmdMock = console.CmdMock{
+	Cmd:    "blkid /some/device -s PTTYPE -o value",
+	Output: "dos\n",
 }
 
 var CmdsExpandPart []console.CmdMock = []console.CmdMock{
@@ -154,10 +144,10 @@ var CmdsExpandPart []console.CmdMock = []console.CmdMock{
 	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
 	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -e /some/device"},
 	{Cmd: "sgdisk -e /some/device"}, pTable,
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "sgdisk -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "blkid /some/device4 -s TYPE -o value", Output: "ext4"},
@@ -173,10 +163,10 @@ var CmdsExpandPartMBR []console.CmdMock = []console.CmdMock{
 	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
 	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListMBR,
+	blkidMBR,
 	{Cmd: "sgdisk -P -g -e /some/device"},
 	{Cmd: "sgdisk -g -e /some/device"}, pTable,
-	fdiskListMBR,
+	blkidMBR,
 	{Cmd: "sgdisk -P -g -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "sgdisk -g -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "blkid /some/device4 -s TYPE -o value", Output: "ext4"},
@@ -190,13 +180,13 @@ var CmdsExpandPartMBR []console.CmdMock = []console.CmdMock{
 var CmdsAddAndExpandPart []console.CmdMock = []console.CmdMock{
 	{Cmd: "lsblk -npo type /some/device", Output: "disk"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -e /some/device"},
 	{Cmd: "sgdisk -e /some/device"},
 	pTableEmpty,
 	{Cmd: "udevadm settle"},
 	{Cmd: "blkid -l --match-token LABEL=MYLABEL -o device"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -n=1:2048:+2097152 -t=1:8300 /some/device"},
 	{Cmd: "sgdisk -n=1:2048:+2097152 -t=1:8300 /some/device"},
 	pTablePostCreation,
@@ -207,7 +197,7 @@ var CmdsAddAndExpandPart []console.CmdMock = []console.CmdMock{
 	{Cmd: "lsblk -ltnpo name,type /some/device", Output: `/some/device disk
 /some/device1 part`},
 	{Cmd: "mkfs.ext2 -L MYLABEL /some/device1"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -d=1 -n=1:2048:+6291456 -t=1:8300 /some/device"},
 	{Cmd: "sgdisk -d=1 -n=1:2048:+6291456 -t=1:8300 /some/device"},
 	{Cmd: "blkid /some/device1 -s TYPE -o value", Output: "ext2"},
@@ -224,10 +214,10 @@ var CmdsExpandPartXfs []console.CmdMock = []console.CmdMock{
 	{Cmd: "blkid -l --match-token LABEL=reflabel -o device", Output: "/some/part"},
 	{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
 	{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -e /some/device"},
 	{Cmd: "sgdisk -e /some/device"}, pTable,
-	fdiskListGPT,
+	blkidGPT,
 	{Cmd: "sgdisk -P -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "sgdisk -d=4 -n=4:178176:+6291456 -c=4:root -t=4:8300 /some/device"},
 	{Cmd: "blkid /some/device4 -s TYPE -o value", Output: "xfs"},
@@ -246,12 +236,12 @@ func CmdsAddPartByLabel(fs string) []console.CmdMock {
 		{Cmd: fmt.Sprintf("blkid -l --match-token LABEL=%s -o device", deviceLabel), Output: "/some/part"},
 		{Cmd: "lsblk -npo pkname /some/part", Output: "/some/device"},
 		{Cmd: "sgdisk --verify /some/device", Output: "the end of the disk"},
-		fdiskListGPT,
+		blkidGPT,
 		{Cmd: "sgdisk -P -e /some/device"},
 		{Cmd: "sgdisk -e /some/device"}, pTable,
 		{Cmd: "udevadm settle"},
 		{Cmd: fmt.Sprintf("blkid -l --match-token LABEL=%s -o device", label)},
-		fdiskListGPT,
+		blkidGPT,
 		{Cmd: "sgdisk -P -n=5:0:+2097152 -t=5:8300 /some/device"},
 		{Cmd: "sgdisk -n=5:0:+2097152 -t=5:8300 /some/device"}, pTable,
 		{Cmd: "udevadm settle"},


### PR DESCRIPTION
We had some issues in Kairos because we were generating MBR partitions, which will change to be GPT partitions in the next release. However, I thought it might still be useful for yip to try to force the GPT partition

relates to https://github.com/kairos-io/kairos/issues/1448