### PR TITLE
Add default values after loading them from the env

### DIFF
--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -50,10 +50,7 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 		return errors.Wrap(err, "getting rawpath for /etc/default/useradd")
 	}
 
-	// Set default home and shell
 	usrDefaults := map[string]string{}
-	usrDefaults["SHELL"] = "/bin/sh"
-	usrDefaults["HOME"] = fmt.Sprintf("/home")
 
 	// Load default home and shell from `/etc/default/useradd`
 	if _, err = os.Stat(useradd); err == nil {
@@ -61,6 +58,14 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 		if err != nil {
 			return errors.Wrapf(err, "could not parse '%s'", useradd)
 		}
+	}
+
+	// Set default home and shell if they are empty
+	if usrDefaults["SHELL"] == "" {
+		usrDefaults["SHELL"] = "/bin/sh"
+	}
+	if usrDefaults["HOME"] == "" {
+		usrDefaults["HOME"] = "/home"
 	}
 
 	primaryGroup := u.Name


### PR DESCRIPTION
If for any reason the /etc/default/useradd doesnt have any of the options that we use (HOME, SHELL) after setting the defaults it gets overwritten via the godotenv.READ so no matter what you set as the default in usrDefaults, it gets overwritten.

This makes sure to first load the default values from the files and then check if they are empty adn fill them with a default value so those values can be used afterwards.

This was causing the user folder to be created under / on debian systems as they do not have that default HOME value in the /etc/default/useradd. Well, its there but its commented out.