### PR TITLE
Remove forced names for cloud-init configs

### DIFF
--- a/pkg/executor/default.go
+++ b/pkg/executor/default.go
@@ -176,7 +176,6 @@ func (e *DefaultExecutor) dirOps(stage, dir string, fs vfs.FS, console plugins.C
 
 			}
 			ops := e.genOpFromSchema(path, stage, *config, fs, console)
-
 			// mark lexicographic order dependency from previous blocks
 			if len(prev) > 0 && len(ops) > 0 {
 				for _, p := range prev {

--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -15,11 +15,15 @@
 package executor_test
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/sanity-io/litter"
+	"github.com/twpayne/go-vfs"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/mudler/yip/pkg/console"
 	"github.com/sirupsen/logrus"
@@ -626,6 +630,40 @@ stages:
 			}
 
 			Expect(string(b)).Should(Equal("rootfs.before\nsecond.rootfs.before\nrootfs\n2\nsecond.rootfs\nsecond.2\ninitramfs\nsecond.initramfs\n"), string(b))
+		})
+		It("has multiple instructions in different files v2", Focus, func() {
+			buf := bytes.Buffer{}
+			l := logrus.New()
+			l.SetOutput(&buf)
+			l.SetLevel(logrus.DebugLevel)
+			def := NewExecutor(WithLogger(l))
+			testConsole := consoletests.New()
+			cmds := []consoletests.CmdMock{
+				{Cmd: "echo \"01\"", Output: "01"},
+				{Cmd: "echo \"02\"", Output: "02"},
+				{Cmd: "echo \"03\"", Output: "03"},
+			}
+			testConsole.AddCmds(cmds)
+
+			temp, err := os.MkdirTemp("", "")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(temp)
+			err = os.WriteFile(filepath.Join(temp, "01_test.yaml"), []byte("#cloud-config\nstages:\n  default:\n    - commands:\n      - echo \"01\"\n"), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(filepath.Join(temp, "02_test.yaml"), []byte("#cloud-config\nstages:\n  default:\n    - commands:\n      - echo \"02\"\n"), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(filepath.Join(temp, "03_test.yaml"), []byte("#cloud-config\nstages:\n  default:\n    - commands:\n      - echo \"03\"\n"), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = def.Run("initramfs", vfs.OSFS, testConsole, temp)
+			g, _ := def.Graph("initramfs", vfs.OSFS, testConsole, temp)
+			Expect(err).Should(BeNil())
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf("Reading '%s'", filepath.Join(temp, "01_test.yaml"))), buf.String())
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf("Reading '%s'", filepath.Join(temp, "02_test.yaml"))), buf.String())
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf("Reading '%s'", filepath.Join(temp, "03_test.yaml"))), buf.String())
+			// 3 commands + init in the graph
+			Expect(len(g)).To(Equal(4), litter.Sdump(g))
+
 		})
 	})
 })

--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -105,7 +105,6 @@ func (cloudInit) Load(s []byte, fs vfs.FS) (*YipConfig, error) {
 	}
 
 	result := &YipConfig{
-		Name: "Cloud init",
 		Stages: map[string][]Stage{
 			"boot": stages,
 			"initramfs": {{

--- a/tests/console/console_mock.go
+++ b/tests/console/console_mock.go
@@ -50,6 +50,9 @@ func (s TestConsoleMock) PopCmd() *CmdMock {
 func (s TestConsoleMock) Run(cmd string, opts ...func(*exec.Cmd)) (string, error) {
 	cmdMock := s.PopCmd()
 	Expect(cmdMock).NotTo(BeNil())
+	Expect(cmdMock.Cmd).NotTo(BeNil())
+	Expect(cmdMock.Cmd).ToNot(Equal(""))
+	Expect(cmd).ToNot(Equal(""))
 	if cmdMock.UseRegexp {
 		if matched, _ := regexp.MatchString(cmdMock.Cmd, cmd); matched {
 			return cmdMock.Output, nil


### PR DESCRIPTION
Otherwise, in files which have no naming for example:

```
#cloud-config
stages:
  default:
    - commands:
      - echo "01"
```

The name of the whole thing will be autogenerated with a fixed string
and it will collide if there is more than one op across different files.

Thus it would somehow miss the files in between the first and the last.
So if you had 5 files it would ignore the 2,3,4 in teh middle and only
run the first and last.

This is due the construction fo the op name which would be like:
`config.Name.Op_number`

Probably because this files are coming from the cloud init loader, the
config name will never change, thus generating ops with the final name
for all of them:

`Cloud init.0`

This patch removes the forced set of the config name to `Cloud init` so
it can be autogenerated based on the file name the op is coming from
thus avoiding any collision in names.

Signed-off-by: Itxaka <itxaka@kairos.io>