### PR TITLE
Add --force flag to systemd_firstboot plugin to overwrite existing files

### DIFF
--- a/pkg/plugins/systemd_firstboot.go
+++ b/pkg/plugins/systemd_firstboot.go
@@ -2,26 +2,34 @@ package plugins
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/mudler/yip/pkg/logger"
 	"github.com/mudler/yip/pkg/schema"
 	"github.com/twpayne/go-vfs"
 )
 
 func SystemdFirstboot(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
-	var errs error
-
-	args := []string{}
+	var err error
+	var args []string
+	var out string
 
 	for k, v := range s.SystemdFirstBoot {
-		args = append(args, fmt.Sprintf("--%s=%s", strings.ToLower(k), v))
+		if v == "true" {
+			args = append(args, fmt.Sprintf("--%s", strings.ToLower(k)))
+		} else {
+			args = append(args, fmt.Sprintf("--%s=%s", strings.ToLower(k), v))
+		}
 	}
 
-	if err := console.RunTemplate(args, "systemd-firstboot %s"); err != nil {
-		errs = multierror.Append(errs, err)
+	if len(args) > 0 {
+		sort.Strings(args)
+		arguments := strings.Join(args, " ")
+		l.Debugf("running 'systemd-firstboot' with arguments: %s", arguments)
+		out, err = console.Run(fmt.Sprintf("systemd-firstboot %s", arguments))
+		l.Debugf("systemd-fristboot output: %s", out)
 	}
 
-	return errs
+	return err
 }

--- a/pkg/plugins/systemd_firstboot_test.go
+++ b/pkg/plugins/systemd_firstboot_test.go
@@ -40,15 +40,15 @@ var _ = Describe("SystemdFirstboot", func() {
 				SystemdFirstBoot: map[string]string{
 					"keymap": "us",
 					"LOCALE": "en_US.UTF-8",
+					"force":  "true",
 				},
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(consoletests.Commands).Should(ContainElements(
-				"systemd-firstboot --locale=en_US.UTF-8",
-				"systemd-firstboot --keymap=us",
+				"systemd-firstboot --force --keymap=us --locale=en_US.UTF-8",
 			))
-			Expect(len(consoletests.Commands)).To(Equal(2))
+			Expect(len(consoletests.Commands)).To(Equal(1))
 		})
 	})
 })


### PR DESCRIPTION
Adding `--force` flag allows to make use of these systemd-firstboot plugin on distros that have default pre-configurations already present after a clean unconfigured installation. From `systemd-firstboot` help page:

```
--force     Overwrite existing files
```

I think it make sense allowing the plugin to overwrite any existing pre-configured file.