### PR TITLE
Set the vfat label using the correct flag

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -809,7 +809,7 @@ func (mkfs MkfsCall) buildOptions() ([]string, error) {
 		opts = append(opts, mkfs.dev)
 	case fatFS:
 		if mkfs.part.FSLabel != "" {
-			opts = append(opts, "-i")
+			opts = append(opts, "-n")
 			opts = append(opts, mkfs.part.FSLabel)
 		}
 		if len(mkfs.customOpts) > 0 {


### PR DESCRIPTION
-i expects a hexadecimal value
-n should be used for the filesystem label

https://man7.org/linux/man-pages/man8/mkfs.vfat.8.html

Needed as part of https://github.com/kairos-io/kairos/issues/2281

so that this config:

```
      add_partitions:
        - fsLabel: COS_GRUB
          size: 64
          pLabel: efi
          filesystem: "fat"
```

won't result in this error:

```
Volume ID must be a hexadecimal number
```