### PR TITLE
Reuse existing user id if it exists

### DIFF
--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -15,18 +15,16 @@
 package plugins_test
 
 import (
-	"io"
-	"io/ioutil"
-	"strings"
-
 	. "github.com/mudler/yip/pkg/plugins"
 	"github.com/mudler/yip/pkg/schema"
 	consoletests "github.com/mudler/yip/tests/console"
-	"github.com/sirupsen/logrus"
-	"github.com/twpayne/go-vfs/v4/vfst"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs/v4/vfst"
+	passwd2 "github.com/willdonnelly/passwd"
+	"io"
+	"io/ioutil"
 )
 
 var _ = Describe("User", func() {
@@ -34,11 +32,55 @@ var _ = Describe("User", func() {
 		testConsole := consoletests.TestConsole{}
 		l := logrus.New()
 		l.SetOutput(io.Discard)
+		existingPasswd := `dbus:x:81:81:System Message Bus:/:/usr/bin/nologin
+root:x:0:0::/root:/bin/bash
+bin:x:1:1::/:/usr/bin/nologin
+daemon:x:2:2::/:/usr/bin/nologin
+mail:x:8:12::/var/spool/mail:/usr/bin/nologin
+ftp:x:14:11::/srv/ftp:/usr/bin/nologin
+http:x:33:33::/srv/http:/usr/bin/nologin
+systemd-coredump:x:980:980:systemd Core Dumper:/:/usr/bin/nologin
+systemd-network:x:979:979:systemd Network Management:/:/usr/bin/nologin
+systemd-oom:x:978:978:systemd Userspace OOM Killer:/:/usr/bin/nologin
+systemd-journal-remote:x:977:977:systemd Journal Remote:/:/usr/bin/nologin
+systemd-resolve:x:976:976:systemd Resolver:/:/usr/bin/nologin
+systemd-timesync:x:975:975:systemd Time Synchronization:/:/usr/bin/nologin
+tss:x:974:974:tss user for tpm2:/:/usr/bin/nologin
+uuidd:x:68:68::/:/usr/bin/nologin
+_talkd:x:973:973:User for legacy talkd server:/:/usr/bin/nologin
+avahi:x:972:972:Avahi mDNS/DNS-SD daemon:/:/usr/bin/nologin
+named:x:40:40:BIND DNS Server:/:/usr/bin/nologin
+colord:x:971:971:Color management daemon:/var/lib/colord:/usr/bin/nologin
+dnsmasq:x:970:970:dnsmasq daemon:/:/usr/bin/nologin
+gdm:x:120:120:Gnome Display Manager:/var/lib/gdm:/usr/bin/nologin
+geoclue:x:969:969:Geoinformation service:/var/lib/geoclue:/usr/bin/nologin
+git:x:968:968:git daemon user:/:/usr/bin/git-shell
+nm-openconnect:x:967:967:NetworkManager OpenConnect:/:/usr/bin/nologin
+nm-openvpn:x:966:966:NetworkManager OpenVPN:/:/usr/bin/nologin
+ntp:x:87:87:Network Time Protocol:/var/lib/ntp:/bin/false
+openvpn:x:965:965:OpenVPN:/:/usr/bin/nologin
+polkitd:x:102:102:PolicyKit daemon:/:/usr/bin/nologin
+rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/bin/nologin
+rpcuser:x:34:34:RPC Service User:/var/lib/nfs:/usr/bin/nologin
+rtkit:x:133:133:RealtimeKit:/proc:/usr/bin/nologin
+usbmux:x:140:140:usbmux user:/:/usr/bin/nologin
+nvidia-persistenced:x:143:143:NVIDIA Persistence Daemon:/:/usr/bin/nologin
+flatpak:x:964:964:Flatpak system helper:/:/usr/bin/nologin
+brltty:x:961:961:Braille Device Daemon:/var/lib/brltty:/usr/bin/nologin
+gluster:x:960:960:GlusterFS daemons:/var/run/gluster:/usr/bin/nologin
+qemu:x:959:959:QEMU user:/:/usr/bin/nologin
+libvirt-qemu:x:957:957:Libvirt QEMU user:/:/usr/bin/nologin
+fwupd:x:956:956:Firmware update daemon:/var/lib/fwupd:/usr/bin/nologin
+passim:x:955:955:Local Caching Server:/usr/share/empty:/usr/bin/nologin
+cups:x:209:209:cups helper user:/:/usr/bin/nologin
+saned:x:953:953:SANE daemon user:/:/usr/bin/nologin
+last:x:999:999:Test user for uid:/:/usr/bin/nologin
+`
 		BeforeEach(func() {
 			consoletests.Reset()
 		})
 		It("change user password", func() {
-			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": "",
 				"/etc/group":  "",
 			})
@@ -52,15 +94,28 @@ var _ = Describe("User", func() {
 
 			shadow, err := fs.ReadFile("/etc/shadow")
 			Expect(err).ShouldNot(HaveOccurred())
-			passwd, err := fs.ReadFile("/etc/passwd")
+			//passwd, err := fs.ReadFile("/etc/passwd")
 			Expect(err).ShouldNot(HaveOccurred())
 			group, err := fs.ReadFile("/etc/group")
 			Expect(err).ShouldNot(HaveOccurred())
 
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+
+			checkDefaultUsers(passwd)
+
 			Expect(string(group)).Should(Equal("foo:x:1000:foo\n"))
 
 			Expect(string(shadow)).Should(ContainSubstring("foo:$fkekofe:"))
-			Expect(string(passwd)).Should(Equal("foo:x:1000:1000:Created by entities:/home/foo:/bin/sh\n"))
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// Last user in the default passwd test data is 999 so this should be 100
+			Expect(foo.Uid).To(Equal("1000"))
 
 			file, err := fs.Open("/home/foo/.ssh/authorized_keys")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -72,7 +127,7 @@ var _ = Describe("User", func() {
 		})
 
 		It("set UID and Lockpasswd", func() {
-			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": "",
 				"/etc/group":  "",
 			})
@@ -83,7 +138,7 @@ var _ = Describe("User", func() {
 				Users: map[string]schema.User{"foo": {
 					PasswordHash: `$fkekofe`,
 					LockPasswd:   true,
-					UID:          "0",
+					UID:          "5000",
 					Homedir:      "/run/foo",
 					Shell:        "/bin/bash",
 				}},
@@ -92,19 +147,32 @@ var _ = Describe("User", func() {
 
 			shadow, err := fs.ReadFile("/etc/shadow")
 			Expect(err).ShouldNot(HaveOccurred())
-			passwd, err := fs.ReadFile("/etc/passwd")
-			Expect(err).ShouldNot(HaveOccurred())
 			group, err := fs.ReadFile("/etc/group")
 			Expect(err).ShouldNot(HaveOccurred())
+
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+
+			checkDefaultUsers(passwd)
 
 			Expect(string(group)).Should(Equal("foo:x:1000:foo\n"))
 
 			Expect(string(shadow)).Should(ContainSubstring("foo:!:"))
-			Expect(string(passwd)).Should(Equal("foo:x:0:1000:Created by entities:/run/foo:/bin/bash\n"))
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/run/foo"))
+			Expect(foo.Shell).To(Equal("/bin/bash"))
+			// we specifically set this uid
+			Expect(foo.Uid).To(Equal("5000"))
+
 		})
 
 		It("edits already existing user password", func() {
-			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": `foo:$6$rfBd56ti$7juhxebonsy.GiErzyxZPkbm.U4lUlv/59D2pvFqlbjVqyJP5f4VgP.EX3FKAeGTAr.GVf0jQmy9BXAZL5mNJ1:18820::::::
 rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtlhizsOxRJLaTfy0bWFZfm2.qYu1:18820::::::`,
 				"/etc/group": "",
@@ -119,15 +187,27 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			shadow, err := fs.ReadFile("/etc/shadow")
 			Expect(err).ShouldNot(HaveOccurred())
-			passwd, err := fs.ReadFile("/etc/passwd")
-			Expect(err).ShouldNot(HaveOccurred())
 			group, err := fs.ReadFile("/etc/group")
 			Expect(err).ShouldNot(HaveOccurred())
+
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+
+			checkDefaultUsers(passwd)
 
 			Expect(string(group)).Should(Equal("foo:x:1000:foo\n"))
 
 			Expect(string(shadow)).Should(ContainSubstring("foo:$fkekofe:"))
-			Expect(string(passwd)).Should(Equal("foo:x:1000:1000:Created by entities:/home/foo:/bin/sh\n"))
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(foo.Uid).To(Equal("1000"))
 
 			file, err := fs.Open("/home/foo/.ssh/authorized_keys")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -139,7 +219,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 		})
 
 		It("adds users to group", func() {
-			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": ``,
 				"/etc/group":  "",
 			})
@@ -174,7 +254,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 		})
 
 		It("Recreates users with the same UID and in order", func() {
-			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": "",
 				"/etc/group":  "",
 			})
@@ -193,18 +273,58 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			passwd, err := fs.ReadFile("/etc/passwd")
-			Expect(err).ShouldNot(HaveOccurred())
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+			checkDefaultUsers(passwd)
 
-			passwdLines := strings.Split(string(passwd), "\n")
-			Expect(passwdLines[0]).Should(Equal("a:x:1000:1000:Created by entities:/home/a:/bin/sh"))
-			Expect(passwdLines[1]).Should(Equal("bar:x:1001:1001:Created by entities:/home/bar:/bin/sh"))
-			Expect(passwdLines[2]).Should(Equal("foo:x:1002:1002:Created by entities:/home/foo:/bin/sh"))
-			Expect(passwdLines[3]).Should(Equal("x:x:1003:1003:Created by entities:/home/x:/bin/sh"))
+			Expect(passwd["a"]).ToNot(BeNil())
+			a := passwd["a"]
+			Expect(a).ToNot(BeNil())
+
+			Expect(a.Gecos).To(Equal("Created by entities"))
+			Expect(a.Pass).To(Equal("x"))
+			Expect(a.Home).To(Equal("/home/a"))
+			Expect(a.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(a.Uid).To(Equal("1000"))
+
+			Expect(passwd["bar"]).ToNot(BeNil())
+			bar := passwd["bar"]
+			Expect(bar).ToNot(BeNil())
+
+			Expect(bar.Gecos).To(Equal("Created by entities"))
+			Expect(bar.Pass).To(Equal("x"))
+			Expect(bar.Home).To(Equal("/home/bar"))
+			Expect(bar.Shell).To(Equal("/bin/sh"))
+			// Next uid
+			Expect(bar.Uid).To(Equal("1001"))
+
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(foo.Uid).To(Equal("1002"))
+
+			Expect(passwd["x"]).ToNot(BeNil())
+			x := passwd["x"]
+			Expect(x).ToNot(BeNil())
+
+			Expect(x.Gecos).To(Equal("Created by entities"))
+			Expect(x.Pass).To(Equal("x"))
+			Expect(x.Home).To(Equal("/home/x"))
+			Expect(x.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(x.Uid).To(Equal("1003"))
+
 			// Manual calling cleanup so we start from scratch
 			cleanup()
 
-			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{"/etc/passwd": "",
+			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": "",
 				"/etc/group":  "",
 			})
@@ -216,14 +336,182 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			passwd, err = fs.ReadFile("/etc/passwd")
+			passdRaw, _ = fs.RawPath("/etc/passwd")
+			passwd, _ = passwd2.ParseFile(passdRaw)
+			checkDefaultUsers(passwd)
+
+			Expect(passwd["a"]).ToNot(BeNil())
+			a = passwd["a"]
+			Expect(a).ToNot(BeNil())
+
+			Expect(a.Gecos).To(Equal("Created by entities"))
+			Expect(a.Pass).To(Equal("x"))
+			Expect(a.Home).To(Equal("/home/a"))
+			Expect(a.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(a.Uid).To(Equal("1000"))
+
+			Expect(passwd["bar"]).ToNot(BeNil())
+			bar = passwd["bar"]
+			Expect(bar).ToNot(BeNil())
+
+			Expect(bar.Gecos).To(Equal("Created by entities"))
+			Expect(bar.Pass).To(Equal("x"))
+			Expect(bar.Home).To(Equal("/home/bar"))
+			Expect(bar.Shell).To(Equal("/bin/sh"))
+			// Next uid
+			Expect(bar.Uid).To(Equal("1001"))
+
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo = passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(foo.Uid).To(Equal("1002"))
+
+			Expect(passwd["x"]).ToNot(BeNil())
+			x = passwd["x"]
+			Expect(x).ToNot(BeNil())
+
+			Expect(x.Gecos).To(Equal("Created by entities"))
+			Expect(x.Pass).To(Equal("x"))
+			Expect(x.Home).To(Equal("/home/x"))
+			Expect(x.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000
+			Expect(x.Uid).To(Equal("1003"))
+		})
+
+		It("Creates the user multiple times, keeping the same UID", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			users := map[string]schema.User{
+				"foo": {PasswordHash: `$fkekofe`},
+			}
+
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			passwdLines = strings.Split(string(passwd), "\n")
-			Expect(passwdLines[0]).Should(Equal("a:x:1000:1000:Created by entities:/home/a:/bin/sh"))
-			Expect(passwdLines[1]).Should(Equal("bar:x:1001:1001:Created by entities:/home/bar:/bin/sh"))
-			Expect(passwdLines[2]).Should(Equal("foo:x:1002:1002:Created by entities:/home/foo:/bin/sh"))
-			Expect(passwdLines[3]).Should(Equal("x:x:1003:1003:Created by entities:/home/x:/bin/sh"))
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+			checkDefaultUsers(passwd)
+
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000, should have not changed
+			Expect(foo.Uid).To(Equal("1000"))
+		})
+
+		It("Creates the user multiple times, keeping the same UID, even if a new users is added", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			users := map[string]schema.User{
+				"foo": {PasswordHash: `$fkekofe`},
+			}
+
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Now we add a new user that is created BEFORE the foo users
+			// They are created alphabetically btw
+			users = map[string]schema.User{
+				"a":   {PasswordHash: `$fkekofe`},
+				"b":   {PasswordHash: `$fkekofe`},
+				"foo": {PasswordHash: `$fkekofe`},
+			}
+			err = User(l, schema.Stage{
+				Users: users,
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwd, _ := passwd2.ParseFile(passdRaw)
+			checkDefaultUsers(passwd)
+
+			Expect(passwd["foo"]).ToNot(BeNil())
+			foo := passwd["foo"]
+			Expect(foo).ToNot(BeNil())
+
+			Expect(foo.Gecos).To(Equal("Created by entities"))
+			Expect(foo.Pass).To(Equal("x"))
+			Expect(foo.Home).To(Equal("/home/foo"))
+			Expect(foo.Shell).To(Equal("/bin/sh"))
+			// first free uid is 1000, should have not changed even with other new users getting new uids
+			Expect(foo.Uid).To(Equal("1000"))
+
+			Expect(passwd["a"]).ToNot(BeNil())
+			a := passwd["a"]
+			Expect(a).ToNot(BeNil())
+
+			Expect(a.Gecos).To(Equal("Created by entities"))
+			Expect(a.Pass).To(Equal("x"))
+			Expect(a.Home).To(Equal("/home/a"))
+			Expect(a.Shell).To(Equal("/bin/sh"))
+			// Should have been created just after our foo user
+			Expect(a.Uid).To(Equal("1001"))
+
+			Expect(passwd["b"]).ToNot(BeNil())
+			b := passwd["b"]
+			Expect(b).ToNot(BeNil())
+
+			Expect(b.Gecos).To(Equal("Created by entities"))
+			Expect(b.Pass).To(Equal("x"))
+			Expect(b.Home).To(Equal("/home/b"))
+			Expect(b.Shell).To(Equal("/bin/sh"))
+			// Should have been created just after our a user
+			Expect(b.Uid).To(Equal("1002"))
+
 		})
 	})
 })
+
+func checkDefaultUsers(userList map[string]passwd2.Entry) {
+	for _, u := range []string{"root", "bin", "daemon", "mail", "ftp", "http", "systemd-coredump", "systemd-network",
+		"systemd-oom", "systemd-journal-remote", "systemd-resolve", "systemd-timesync", "tss", "_talkd", "uuid",
+		"avahi", "named", "colord", "dnsmasq", "gdm", "geoclue", "git", "nm-openconnect", "nm-openvpn", "ntp",
+		"openvpn", "polkitd", "rpc", "rpcuser", "rtkit", "usbmux", "nvidia-persistenced", "flatpak", "brltty",
+		"gluster", "qemu", "libvirt-qemu", "fwupd", "passim", "cups", "saned", "last",
+	} {
+		Expect(userList[u]).ToNot(BeNil())
+	}
+
+}


### PR DESCRIPTION
We dont want to fully skip the user update if it exists as it may be for a specific reason like updating groups and such, but if the entry does not have a specific user id set by the user object and the user already exists in the passwd file, we should reuse the userid as to not break existing files that may have permissions linked to that user

This should fix:
 - users in config files appearing more than once, so their uid wont change
 - ssh keys added to users than are updated after the key creation
 - anything else adding a user to the passwd file and bumping the next uid free, as our calculation picks the latest free uid