### PR TITLE
Add btrfs partition support

### DIFF
--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Layout", func() {
 
 		It("Works on an non-xfs fs with a label longer than 12 chars", func() {
 			label = "LABEL_TOO_LONG_FOR_XFS"
-			for _, filesystem := range []string{"ext2", "ext3", "ext4"} {
+			for _, filesystem := range []string{"ext2", "ext3", "ext4", "btrfs"} {
 				testConsole := console.New()
 				testConsole.AddCmds(CmdsAddPartByLabel(filesystem))
 				err := Layout(l, schema.Stage{


### PR DESCRIPTION
Goal of this PR is to be able to handle simple single disk btrfs formated partitions.

This way the persistent partition can be used by tools like https://github.com/lxc/incus for containers and VM disks