### PR TITLE
Improve timesyncd plugin

### DIFF
--- a/pkg/plugins/timesyncd.go
+++ b/pkg/plugins/timesyncd.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/mudler/yip/pkg/logger"
 	"github.com/mudler/yip/pkg/schema"
@@ -9,17 +10,23 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-const timeSyncd = "/etc/systemd/timesyncd.conf"
+const timeSyncd = "/etc/systemd/timesyncd.conf.d/10-yip.conf"
 
 func Timesyncd(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
 	if len(s.TimeSyncd) == 0 {
 		return nil
 	}
 	var errs error
-
 	path, err := fs.RawPath(timeSyncd)
 	if err != nil {
 		return err
+	}
+
+	if _, err := fs.Stat(filepath.Dir(timeSyncd)); os.IsNotExist(err) {
+		err = fs.Mkdir(filepath.Dir(timeSyncd), os.ModeDir|os.ModePerm)
+		if err != nil {
+			return err
+		}
 	}
 
 	if _, err := fs.Stat(timeSyncd); os.IsNotExist(err) {
@@ -33,7 +40,11 @@ func Timesyncd(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) e
 	}
 
 	for k, v := range s.TimeSyncd {
-		cfg.Section("Time").Key(k).SetValue(v)
+		if v == "" {
+			cfg.Section("Time").Key(k).SetValue("\"\"")
+		} else {
+			cfg.Section("Time").Key(k).SetValue(v)
+		}
 	}
 
 	cfg.SaveTo(path)

--- a/pkg/plugins/timesyncd_test.go
+++ b/pkg/plugins/timesyncd_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Timesyncd", func() {
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			file, err := fs.Open("/etc/systemd/timesyncd.conf")
+			file, err := fs.Open("/etc/systemd/timesyncd.conf.d/10-yip.conf")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			b, err := ioutil.ReadAll(file)


### PR DESCRIPTION
 - Set empty value if the value as strings if value is empty instead of omitting the value
 - Write config to /etc/systemd/timesyncd.conf.d/10-yip.conf to properly override the existing config and any others shipped with the system