### PR TITLE
Print a message if a stage is taking more than 10 seconds

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -15,14 +15,11 @@
 package console
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
-	"time"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/mudler/yip/pkg/logger"
 	"github.com/sirupsen/logrus"
+	"os/exec"
 )
 
 type StandardConsole struct {
@@ -55,37 +52,13 @@ func (s StandardConsole) Run(cmd string, opts ...func(cmd *exec.Cmd)) (string, e
 	for _, o := range opts {
 		o(c)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Start the timer log
-	go displayProgress(ctx, s.logger, 10*time.Second, fmt.Sprintf("Still running command '%s'", cmd))
-
-	// Run the command
 	out, err := c.CombinedOutput()
-
-	// Stop the timer log
-	cancel()
 
 	if err != nil {
 		return string(out), fmt.Errorf("failed to run %s: %v", cmd, err)
 	}
 
 	return string(out), err
-}
-
-func displayProgress(ctx context.Context, log logger.Interface, tick time.Duration, message string) {
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			log.Info(message)
-		}
-	}
 }
 
 func (s StandardConsole) Start(cmd *exec.Cmd, opts ...func(cmd *exec.Cmd)) error {

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -55,6 +55,7 @@ func (s StandardConsole) Run(cmd string, opts ...func(cmd *exec.Cmd)) (string, e
 		o(c)
 	}
 	displayProgress(s.logger, 10*time.Second, fmt.Sprintf("Still running command '%s'", cmd))
+
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("failed to run %s: %v", cmd, err)
@@ -63,7 +64,7 @@ func (s StandardConsole) Run(cmd string, opts ...func(cmd *exec.Cmd)) (string, e
 	return string(out), err
 }
 
-func displayProgress(log logger.Interface, tick time.Duration, message string) chan bool {
+func displayProgress(log logger.Interface, tick time.Duration, message string) {
 	ticker := time.NewTicker(tick)
 	done := make(chan bool)
 
@@ -79,7 +80,7 @@ func displayProgress(log logger.Interface, tick time.Duration, message string) c
 		}
 	}()
 
-	return done
+	return
 }
 
 func (s StandardConsole) Start(cmd *exec.Cmd, opts ...func(cmd *exec.Cmd)) error {


### PR DESCRIPTION
With a config like this:

```
#cloud-config

stages:
  initramfs:
    - name: "test"
      commands:
        - sleep 15
        - echo "hello"
```

This is the output:

```
$ LOGLEVEL=debug go run main.go -s initramfs .
INFO[0000] yip version -g                               
INFO[0000] Running stage: initramfs                     
DEBU[0000] Generating op for stage 'test.yaml.0'        
DEBU[0000] Generating op for stage 'test.yaml.test'     
DEBU[0000] Reading 'test.yaml'                          
DEBU[0000] Executing stage 'test.yaml.0'                
INFO[0000] Processing stage step 'test.yaml.0'. ( commands: 0, files: 0, ... ) 
DEBU[0000] Stage: schema.Stage{}                        
DEBU[0000] Device field empty, skipping layout plugin   
DEBU[0000] Reading 'test.yaml'                          
DEBU[0000] Executing stage 'test.yaml.test'             
INFO[0000] Processing stage step 'test.yaml.test'. ( commands: 2, files: 0, ... ) 
DEBU[0000] Stage: schema.Stage{
  Commands: []string{
    "sleep 15",
    "echo \"hello\"",
  },
  Name: "test",
} 
DEBU[0000] running command `sleep 15`                   
INFO[0010] Still running command 'sleep 15'             
DEBU[0015] Empty command output                         
DEBU[0015] running command `echo "hello"`               
DEBU[0015] Command output: hello                        
DEBU[0015] Device field empty, skipping layout plugin   
INFO[0015] Done executing stage 'initramfs'    
```