### PR TITLE
Use SUSE installer for SLE family

### DIFF
--- a/pkg/plugins/packages.go
+++ b/pkg/plugins/packages.go
@@ -42,6 +42,7 @@ const (
 	Alpine             Distro = "alpine"
 	OpenSUSELeap       Distro = "opensuse-leap"
 	OpenSUSETumbleweed Distro = "opensuse-tumbleweed"
+	SUSE               Distro = "suse"
 )
 
 // Packages runs the package manager to try to install/remove/upgrade/refresh packages
@@ -183,7 +184,7 @@ func identifyInstaller(fsys vfs.FS) Installer {
 		return PacmanInstaller
 	case Alpine:
 		return AlpineInstaller
-	case OpenSUSELeap, OpenSUSETumbleweed:
+	case OpenSUSELeap, OpenSUSETumbleweed, SUSE:
 		return SUSEInstaller
 	default:
 		return UnknownInstaller


### PR DESCRIPTION
```
218aff01fc75:/ # cat /etc/os-release
NAME="SLES"
VERSION="15-SP6"
VERSION_ID="15.6"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP6"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp6"
DOCUMENTATION_URL="https://documentation.suse.com/"
```