### PR TITLE
Fix rhel package installer identification

### DIFF
--- a/pkg/plugins/packages.go
+++ b/pkg/plugins/packages.go
@@ -33,7 +33,7 @@ type Distro string
 const (
 	Debian             Distro = "debian"
 	Ubuntu             Distro = "ubuntu"
-	RedHat             Distro = "redhat"
+	RedHat             Distro = "rhel"
 	CentOS             Distro = "centos"
 	RockyLinux         Distro = "rocky"
 	AlmaLinux          Distro = "almalinux"


### PR DESCRIPTION
Part of https://github.com/kairos-io/kairos/issues/3454