### PR TITLE
Add missing If plugins

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -72,6 +72,8 @@ func NewExecutor(opts ...Options) Executor {
 			plugins.IfConditional,
 			plugins.OnlyIfOS,
 			plugins.OnlyIfOSVersion,
+			plugins.IfArch,
+			plugins.IfServiceManager,
 		},
 		plugins: []Plugin{
 			plugins.DNS,


### PR DESCRIPTION
Plugins were there and tested but never enabled in the default executor