### PR TITLE
Values and pointers and copies, oh my

### DIFF
--- a/pkg/executor/default_test.go
+++ b/pkg/executor/default_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Executor", func() {
 				}},
 			}}
 
-			def.Apply("foo", config, fs, testConsole)
+			def.Apply("foo", config, fs, &testConsole)
 			file, err := fs.Open("/tmp/test/foo")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -86,7 +86,7 @@ var _ = Describe("Executor", func() {
 				}},
 			}}
 
-			def.Apply("foo", config, fs, testConsole)
+			def.Apply("foo", config, fs, &testConsole)
 			file, err := fs.Open("/tmp/test/foo")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -105,7 +105,7 @@ var _ = Describe("Executor", func() {
 				}},
 			}}
 
-			def.Apply("foo", config, fs, testConsole)
+			def.Apply("foo", config, fs, &testConsole)
 			_, err = fs.Open("/tmp/test/bbb")
 			Expect(err).Should(HaveOccurred())
 		})
@@ -123,7 +123,7 @@ var _ = Describe("Executor", func() {
 				}},
 			}}
 
-			def.Apply("foo", config, fs, testConsole)
+			def.Apply("foo", config, fs, &testConsole)
 			_, err = fs.Open("/tmp/boo")
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -372,7 +372,7 @@ users: "one,two,tree"
 `,
 						}}}}},
 			}
-			err = def.Apply("foo", config, fs, testConsole)
+			err = def.Apply("foo", config, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := os.Open(temp + "/foo")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -407,7 +407,7 @@ gid: 1
 users: "one,two,tree"
 `,
 						}}}}}}
-			err = def.Apply("foo", config, fs, testConsole)
+			err = def.Apply("foo", config, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := os.Open(temp + "/foo")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/plugins/commands_test.go
+++ b/pkg/plugins/commands_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Commands", func() {
 		l.SetOutput(io.Discard)
 
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole.Reset()
 		})
 		It("execute commands", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -44,9 +44,9 @@ var _ = Describe("Commands", func() {
 
 			err = Commands(l, schema.Stage{
 				Commands: []string{"echo foo", "echo bar"},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(consoletests.Commands).Should(Equal([]string{"echo foo", "echo bar"}))
+			Expect(testConsole.Commands).Should(Equal([]string{"echo foo", "echo bar"}))
 		})
 		It("execute templated commands", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -55,9 +55,9 @@ var _ = Describe("Commands", func() {
 			arch := runtime.GOARCH
 			err = Commands(l, schema.Stage{
 				Commands: []string{"echo {{.Values.os.architecture}}", "echo bar"},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(consoletests.Commands).Should(Equal([]string{"echo " + arch, "echo bar"}))
+			Expect(testConsole.Commands).Should(Equal([]string{"echo " + arch, "echo bar"}))
 		})
 	})
 })

--- a/pkg/plugins/datasource_test.go
+++ b/pkg/plugins/datasource_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Datasources", func() {
 				DataSources: schema.DataSource{
 					Providers: []string{"cdrom"},
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).To(HaveOccurred())
 			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
 			_, err = fs.Stat(providers.ConfigPath)
@@ -71,7 +71,7 @@ var _ = Describe("Datasources", func() {
 				DataSources: schema.DataSource{
 					Providers: prv,
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			elapsed := time.Since(start)
 			Expect(err).To(HaveOccurred())
 			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
@@ -96,7 +96,7 @@ var _ = Describe("Datasources", func() {
 					// This is the path that the file datasource is using. It doesn't use any vfs passed, so it checks the real os fs
 					Path: filepath.Join(temp, "datasource"),
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ToNot(HaveOccurred())
 			// Final userdata its set on the test fs
 			_, err = fs.Stat(filepath.Join(providers.ConfigPath, "userdata.yaml"))

--- a/pkg/plugins/dir_test.go
+++ b/pkg/plugins/dir_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Files", func() {
 
 			err = EnsureDirectories(l, schema.Stage{
 				Directories: []schema.Directory{{Path: "/tmp/dir", Permissions: 0740, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			inf, _ := fs.Stat("/tmp/dir")
 			Expect(inf.Mode().Perm()).To(Equal(os.FileMode(int(0740))))
@@ -54,7 +54,7 @@ var _ = Describe("Files", func() {
 			Expect(inf.Mode().Perm()).To(Equal(os.FileMode(int(0755))))
 			err = EnsureDirectories(l, schema.Stage{
 				Directories: []schema.Directory{{Path: "/tmp/dir", Permissions: 0740, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			inf, _ = fs.Stat("/tmp/dir")
 			Expect(inf.Mode().Perm()).To(Equal(os.FileMode(int(0740))))
@@ -66,7 +66,7 @@ var _ = Describe("Files", func() {
 			defer cleanup()
 			err = EnsureDirectories(l, schema.Stage{
 				Directories: []schema.Directory{{Path: "/tmp/dir/subdir1/subdir2", Permissions: 0740, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			inf, _ := fs.Stat("/tmp")
 			Expect(inf.Mode().Perm()).To(Equal(os.FileMode(int(0755))))

--- a/pkg/plugins/dns_test.go
+++ b/pkg/plugins/dns_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Dns", func() {
 		testConsole := consoletests.TestConsole{}
 
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole.Reset()
 		})
 		It("sets dns", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/tmp/test/bar": "boo"})
@@ -42,7 +42,7 @@ var _ = Describe("Dns", func() {
 
 			defer cleanup()
 
-			err = DNS(logrus.New(), schema.Stage{Dns: schema.DNS{Path: temp + "/foo", Nameservers: []string{"8.8.8.8"}}}, fs, testConsole)
+			err = DNS(logrus.New(), schema.Stage{Dns: schema.DNS{Path: temp + "/foo", Nameservers: []string{"8.8.8.8"}}}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := os.Open(temp + "/foo")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/plugins/download_test.go
+++ b/pkg/plugins/download_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Download", func() {
 
 			err = Download(l, schema.Stage{
 				Downloads: []schema.Download{{Path: "/tmp/test/foo", URL: testURL, Permissions: 0777, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := fs.Open("/tmp/test/foo")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Download", func() {
 
 			err = Download(l, schema.Stage{
 				Downloads: []schema.Download{{Path: "/tmp/test/", URL: testURL, Permissions: 0777, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := fs.Open("/tmp/test/unittest.txt")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/plugins/environment_test.go
+++ b/pkg/plugins/environment_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Environment", func() {
 
 			err = Environment(l, schema.Stage{
 				Environment: map[string]string{"foo": "0"},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err := fs.Open("/etc/environment")
@@ -62,7 +62,7 @@ var _ = Describe("Environment", func() {
 			err = Environment(l, schema.Stage{
 				Environment:     map[string]string{"foo": "0"},
 				EnvironmentFile: "/run/cos/cos-layout.env",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			inf, _ := fs.Stat("/run/cos")

--- a/pkg/plugins/files_test.go
+++ b/pkg/plugins/files_test.go
@@ -33,6 +33,9 @@ var _ = Describe("Files", func() {
 	Context("creating", func() {
 		testConsole := consoletests.TestConsole{}
 		l := logrus.New()
+		AfterEach(func() {
+			testConsole.Reset()
+		})
 		It("creates a /tmp/test/foo file", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/tmp/test/bar": "boo"})
 			Expect(err).Should(BeNil())
@@ -40,7 +43,7 @@ var _ = Describe("Files", func() {
 
 			err = EnsureFiles(l, schema.Stage{
 				Files: []schema.File{{Path: "/tmp/test/foo", Content: "Test", Permissions: 0777, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := fs.Open("/tmp/test/foo")
 			b, err := ioutil.ReadAll(file)
@@ -58,7 +61,7 @@ var _ = Describe("Files", func() {
 			Expect(err).NotTo(BeNil())
 			err = EnsureFiles(l, schema.Stage{
 				Files: []schema.File{{Path: "/testarea/dir/subdir/foo", Content: "Test", Permissions: 0640, Owner: os.Getuid(), Group: os.Getgid()}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err := fs.Open("/testarea/dir/subdir/foo")

--- a/pkg/plugins/git_test.go
+++ b/pkg/plugins/git_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Git", func() {
 					URL:  "https://gist.github.com/mudler/13d2c42fd2cf7fc33cdb8cae6b5bdd57",
 					Path: "/testarea/foo",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := fs.Open("/testarea/foo/unittest.txt")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -85,7 +85,7 @@ var _ = Describe("Git", func() {
 					URL:  "https://gist.github.com/mudler/13d2c42fd2cf7fc33cdb8cae6b5bdd57",
 					Path: "/testarea",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			file, err := fs.Open("/testarea/unittest.txt")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -107,7 +107,7 @@ var _ = Describe("Git", func() {
 					URL:  "https://gist.github.com/mudler/13d2c42fd2cf7fc33cdb8cae6b5bdd57",
 					Path: "/testarea",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			fs.WriteFile("/testarea/unittest.txt", []byte("foo"), os.ModePerm)
@@ -127,7 +127,7 @@ var _ = Describe("Git", func() {
 					Path:   "/testarea",
 					Branch: "master",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err = fs.Open("/testarea/unittest.txt")
@@ -154,7 +154,7 @@ var _ = Describe("Git", func() {
 
 					Auth: schema.Auth{PrivateKey: testPrivateKey, PublicKey: gitlabKey},
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			fs.WriteFile("/testarea/test.txt", []byte("foo"), os.ModePerm)
@@ -175,7 +175,7 @@ var _ = Describe("Git", func() {
 					Path:   "/testarea",
 					Branch: "main",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err = fs.Open("/testarea/test.txt")

--- a/pkg/plugins/if_test.go
+++ b/pkg/plugins/if_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		Expect(err).Should(BeNil())
 	})
 	AfterEach(func() {
-		consoletests.Reset()
+		testConsole.Reset()
 		cleanup()
 	})
 	Describe("IfConditional", func() {
@@ -47,10 +47,10 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 			It("Executes", func() {
 				err = IfConditional(logrus.New(), schema.Stage{
 					If: "exit 1",
-				}, fs, testConsole)
+				}, fs, &testConsole)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(consoletests.Commands).Should(Equal([]string{"exit 1"}))
+				Expect(testConsole.Commands).Should(Equal([]string{"exit 1"}))
 			})
 		})
 	})
@@ -58,7 +58,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Executes", func() {
 			err = OnlyIfOS(logrus.New(), schema.Stage{
 				OnlyIfOs: "weird",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(SkipOnlyOs, "weird")))
@@ -69,7 +69,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Executes", func() {
 			err = OnlyIfOSVersion(logrus.New(), schema.Stage{
 				OnlyIfOsVersion: "weird",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(SkipOnlyOsVersion, "weird")), err.Error())
@@ -79,7 +79,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Fails with no match", func() {
 			err = IfArch(logrus.New(), schema.Stage{
 				OnlyIfArch: "weird",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(SkipOnlyArch, runtime.GOARCH, "weird")), err.Error())
@@ -87,7 +87,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Succeeds", func() {
 			err = IfArch(logrus.New(), schema.Stage{
 				OnlyIfArch: runtime.GOARCH,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -96,7 +96,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Fails if not supported", func() {
 			err = IfServiceManager(logrus.New(), schema.Stage{
 				OnlyIfServiceManager: "weird",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(SkipNotSupportedServiceManager, "weird")))
@@ -104,7 +104,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 		It("Fails if not matched", func() {
 			err = IfServiceManager(logrus.New(), schema.Stage{
 				OnlyIfServiceManager: "openrc",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(SkipOnlyServiceManager, "openrc")))
@@ -117,7 +117,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 
 			err = IfServiceManager(logrus.New(), schema.Stage{
 				OnlyIfServiceManager: "systemd",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(SkipBothServices))
@@ -129,7 +129,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 
 			err = IfServiceManager(logrus.New(), schema.Stage{
 				OnlyIfServiceManager: "systemd",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -140,7 +140,7 @@ var _ = Describe("Conditionals", Label("conditionals"), func() {
 
 			err = IfServiceManager(logrus.New(), schema.Stage{
 				OnlyIfServiceManager: "openrc",
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/pkg/plugins/packages_test.go
+++ b/pkg/plugins/packages_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Commands", Label("packages"), func() {
 		l.SetOutput(io.Discard)
 
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole.Reset()
 		})
 		It("execute proper install commands", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -33,9 +33,9 @@ var _ = Describe("Commands", Label("packages"), func() {
 					Remove:  []string{"baz", "qux"},
 					Refresh: true,
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(consoletests.Commands).Should(Equal([]string{"apt-get -y update", "apt-get -y --no-install-recommends install foo bar", "apt-get -y remove baz qux"}))
+			Expect(testConsole.Commands).Should(Equal([]string{"apt-get -y update", "apt-get -y --no-install-recommends install foo bar", "apt-get -y remove baz qux"}))
 		})
 		It("execute proper install commands for different OS", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -91,10 +91,10 @@ var _ = Describe("Commands", Label("packages"), func() {
 
 			for _, t := range tests {
 				Expect(fs.WriteFile("/etc/os-release", []byte(t.osRelease), 0644)).ToNot(HaveOccurred())
-				err = Packages(l, stage, fs, testConsole)
+				err = Packages(l, stage, fs, &testConsole)
 				Expect(err).ShouldNot(HaveOccurred(), t.osRelease)
-				Expect(consoletests.Commands).Should(Equal(t.expected), litter.Sdump(t.osRelease))
-				consoletests.Reset()
+				Expect(testConsole.Commands).Should(Equal(t.expected), litter.Sdump(t.osRelease))
+				testConsole.Reset()
 			}
 		})
 		It("fails if it cant identify the systems package manager", func() {
@@ -107,7 +107,7 @@ var _ = Describe("Commands", Label("packages"), func() {
 					Remove:  []string{"baz", "qux"},
 					Refresh: true,
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unknown package manager"))
 		})

--- a/pkg/plugins/ssh_test.go
+++ b/pkg/plugins/ssh_test.go
@@ -44,7 +44,7 @@ var _ = Describe("SSH", func() {
 
 			err = SSH(l, schema.Stage{
 				SSHKeys: map[string][]string{"foo": {"efafeeafea,t,t,pgl3,pbar", "github:mudler"}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			//Expect(err).ShouldNot(HaveOccurred())
 
 			file, err := fs.Open("/home/foo/.ssh/authorized_keys")

--- a/pkg/plugins/sysctl_test.go
+++ b/pkg/plugins/sysctl_test.go
@@ -34,6 +34,10 @@ var _ = Describe("Sysctl", func() {
 		l := logrus.New()
 		l.SetOutput(io.Discard)
 
+		AfterEach(func() {
+			testConsole.Reset()
+		})
+
 		It("configures a /sys/proc setting", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/proc/sys/debug/.keep": ""})
 			Expect(err).Should(BeNil())
@@ -41,7 +45,7 @@ var _ = Describe("Sysctl", func() {
 
 			err = Sysctl(l, schema.Stage{
 				Sysctl: map[string]string{"debug.exception-trace": "0"},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err := fs.Open("/proc/sys/debug/exception-trace")

--- a/pkg/plugins/systemctl_test.go
+++ b/pkg/plugins/systemctl_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Systemctl", func() {
 	Context("parsing yip file", func() {
 		testConsole := consoletests.TestConsole{}
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole.Reset()
 		})
 		It("starts and enables services", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -45,10 +45,10 @@ var _ = Describe("Systemctl", func() {
 					Mask:    []string{"baz"},
 					Start:   []string{"moz"},
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(consoletests.Commands).Should(Equal([]string{"systemctl enable foo", "systemctl disable bar", "systemctl mask baz", "systemctl start moz"}))
+			Expect(testConsole.Commands).Should(Equal([]string{"systemctl enable foo", "systemctl disable bar", "systemctl mask baz", "systemctl start moz"}))
 		})
 		Context("Overrides", func() {
 			It("creates override files", func() {
@@ -65,10 +65,10 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(fs.Stat("/etc/systemd/system/foo.service.d/override-yip.conf")).ToNot(BeNil())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				content, err := fs.ReadFile("/etc/systemd/system/foo.service.d/override-yip.conf")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).Should(Equal("[Unit]\nbar=baz"))
@@ -87,10 +87,10 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(fs.Stat("/etc/systemd/system/foo.service.d/override-yip.conf")).ToNot(BeNil())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				content, err := fs.ReadFile("/etc/systemd/system/foo.service.d/override-yip.conf")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).Should(Equal("[Unit]\nbar=baz"))
@@ -110,13 +110,13 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ShouldNot(HaveOccurred())
 				_, err = fs.Stat("/etc/systemd/system/foo.service.d/override-yip.conf")
 				Expect(err).ToNot(BeNil())
 				_, err = fs.Stat("/etc/systemd/system/foo.service.d/override-foo.conf")
 				Expect(err).To(BeNil())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				content, err := fs.ReadFile("/etc/systemd/system/foo.service.d/override-foo.conf")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).Should(Equal("[Unit]\nbar=baz"))
@@ -136,13 +136,13 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ShouldNot(HaveOccurred())
 				_, err = fs.Stat("/etc/systemd/system/foo.service.d/override-yip.conf")
 				Expect(err).ToNot(BeNil())
 				_, err = fs.Stat("/etc/systemd/system/foo.service.d/override-foo.conf")
 				Expect(err).To(BeNil())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				content, err := fs.ReadFile("/etc/systemd/system/foo.service.d/override-foo.conf")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).Should(Equal("[Unit]\nbar=baz"))
@@ -163,12 +163,12 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ToNot(HaveOccurred())
 				// Should not create the directory
 				_, err = fs.Stat("/etc/systemd/system/")
 				Expect(err).To(HaveOccurred())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				Expect(buf.String()).Should(ContainSubstring(ErrorEmptyOverrideService))
 			})
 			It("doesn't do anything if content is missing", func() {
@@ -187,12 +187,12 @@ var _ = Describe("Systemctl", func() {
 							},
 						},
 					},
-				}, fs, testConsole)
+				}, fs, &testConsole)
 				Expect(err).ToNot(HaveOccurred())
 				// Should not create the directory
 				_, err = fs.Stat("/etc/systemd/system/")
 				Expect(err).To(HaveOccurred())
-				Expect(consoletests.Commands).Should(BeEmpty())
+				Expect(testConsole.Commands).Should(BeEmpty())
 				Expect(buf.String()).Should(ContainSubstring(fmt.Sprintf(ErrorEmptyOverrideContent, "test.service")))
 			})
 		})

--- a/pkg/plugins/systemd_firstboot_test.go
+++ b/pkg/plugins/systemd_firstboot_test.go
@@ -15,11 +15,9 @@
 package plugins_test
 
 import (
-	"fmt"
 	. "github.com/mudler/yip/pkg/plugins"
 	"github.com/mudler/yip/pkg/schema"
 	consoletests "github.com/mudler/yip/tests/console"
-	"github.com/sanity-io/litter"
 	"github.com/sirupsen/logrus"
 	"github.com/twpayne/go-vfs/v4/vfst"
 
@@ -51,9 +49,6 @@ var _ = Describe("SystemdFirstboot", Label("systemd-firstboot"), func() {
 				},
 			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
-
-			litter.Config.HidePrivateFields = false
-			fmt.Println(litter.Sdump(testConsole.Commands))
 
 			Expect(testConsole.Commands).Should(ContainElements(
 				"systemd-firstboot --force --keymap=us --locale=en_US.UTF-8",

--- a/pkg/plugins/systemd_firstboot_test.go
+++ b/pkg/plugins/systemd_firstboot_test.go
@@ -15,9 +15,11 @@
 package plugins_test
 
 import (
+	"fmt"
 	. "github.com/mudler/yip/pkg/plugins"
 	"github.com/mudler/yip/pkg/schema"
 	consoletests "github.com/mudler/yip/tests/console"
+	"github.com/sanity-io/litter"
 	"github.com/sirupsen/logrus"
 	"github.com/twpayne/go-vfs/v4/vfst"
 
@@ -25,11 +27,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("SystemdFirstboot", func() {
+var _ = Describe("SystemdFirstboot", Label("systemd-firstboot"), func() {
 	Context("parsing yip file", func() {
-		testConsole := consoletests.TestConsole{}
+		var testConsole consoletests.TestConsole
+
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole = consoletests.TestConsole{}
+		})
+
+		AfterEach(func() {
+			testConsole.Reset()
 		})
 		It("sets first-boot configuration", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
@@ -42,13 +49,16 @@ var _ = Describe("SystemdFirstboot", func() {
 					"LOCALE": "en_US.UTF-8",
 					"force":  "true",
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(consoletests.Commands).Should(ContainElements(
+			litter.Config.HidePrivateFields = false
+			fmt.Println(litter.Sdump(testConsole.Commands))
+
+			Expect(testConsole.Commands).Should(ContainElements(
 				"systemd-firstboot --force --keymap=us --locale=en_US.UTF-8",
 			))
-			Expect(len(consoletests.Commands)).To(Equal(1))
+			Expect(len(testConsole.Commands)).To(Equal(1))
 		})
 	})
 })

--- a/pkg/plugins/timesyncd_test.go
+++ b/pkg/plugins/timesyncd_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Timesyncd", func() {
 
 			err = Timesyncd(l, schema.Stage{
 				TimeSyncd: map[string]string{"NTP": "0.pool"},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			file, err := fs.Open("/etc/systemd/timesyncd.conf.d/10-yip.conf")

--- a/pkg/plugins/unpack_image_test.go
+++ b/pkg/plugins/unpack_image_test.go
@@ -30,7 +30,7 @@ var _ = Describe("UnpackImage", Label("unpack_image"), func() {
 		fs = vfs.OSFS
 	})
 	AfterEach(func() {
-		consoletests.Reset()
+		testConsole.Reset()
 		Expect(os.RemoveAll(target)).ToNot(HaveOccurred())
 	})
 
@@ -43,7 +43,7 @@ var _ = Describe("UnpackImage", Label("unpack_image"), func() {
 						Target: target,
 					},
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err := os.Stat(target)
@@ -60,7 +60,7 @@ var _ = Describe("UnpackImage", Label("unpack_image"), func() {
 						Platform: "linux/arm64",
 					},
 				},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err := os.Stat(target)

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -121,7 +121,7 @@ saned:x:953:953:SANE daemon user:/:/usr/bin/nologin
 last:x:999:999:Test user for uid:/:/usr/bin/nologin
 `
 		BeforeEach(func() {
-			consoletests.Reset()
+			testConsole.Reset()
 		})
 		It("change user password", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
@@ -133,7 +133,7 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 
 			err = User(l, schema.Stage{
 				Users: map[string]schema.User{"foo": {PasswordHash: `$fkekofe`, SSHAuthorizedKeys: []string{"github:mudler", "efafeeafea,t,t,pgl3,pbar"}}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			shadow, err := fs.ReadFile("/etc/shadow")
@@ -187,7 +187,7 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 					Homedir:      "/run/foo",
 					Shell:        "/bin/bash",
 				}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			shadow, err := fs.ReadFile("/etc/shadow")
@@ -229,7 +229,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: map[string]schema.User{"foo": {PasswordHash: `$fkekofe`, Homedir: "/home/foo", SSHAuthorizedKeys: []string{"github:mudler", "efafeeafea,t,t,pgl3,pbar"}}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			shadow, err := fs.ReadFile("/etc/shadow")
@@ -277,12 +277,12 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: map[string]schema.User{"admin": {PasswordHash: `$fkekofe`, Homedir: "/home/foo", SSHAuthorizedKeys: []string{"github:mudler", "efafeeafea,t,t,pgl3,pbar"}}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			err = User(l, schema.Stage{
 				Users: map[string]schema.User{"bar": {Groups: []string{"admin"}, PasswordHash: `$fkekofe`, Homedir: "/home/foo", SSHAuthorizedKeys: []string{"github:mudler", "efafeeafea,t,t,pgl3,pbar"}}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			group, err := fs.ReadFile("/etc/group")
@@ -292,7 +292,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: map[string]schema.User{"baz": {Homedir: "/home/foo", Groups: []string{"admin"}}},
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			group, err = fs.ReadFile("/etc/group")
@@ -319,7 +319,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			passdRaw, _ := fs.RawPath("/etc/passwd")
@@ -381,7 +381,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			passdRaw, _ = fs.RawPath("/etc/passwd")
@@ -446,23 +446,23 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			passdRaw, _ := fs.RawPath("/etc/passwd")
@@ -497,7 +497,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Now we add a new user that is created BEFORE the foo users
@@ -509,7 +509,7 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 			}
 			err = User(l, schema.Stage{
 				Users: users,
-			}, fs, testConsole)
+			}, fs, &testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			passdRaw, _ := fs.RawPath("/etc/passwd")

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -17,10 +17,8 @@ func (s *TestConsole) Run(cmd string, opts ...func(*exec.Cmd)) (string, error) {
 	for _, o := range opts {
 		o(c)
 	}
-	fmt.Println("Commands:", s.Commands)
 	s.Commands = append(s.Commands, cmd)
 	s.Commands = append(s.Commands, c.Args...)
-	fmt.Println("Commands after append:", s.Commands)
 
 	return "", nil
 }

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -2,51 +2,41 @@ package consoletests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os/exec"
 
 	"github.com/apex/log"
 	"github.com/hashicorp/go-multierror"
 )
 
-var Commands []string
-var Stdin string
-
 type TestConsole struct {
+	Commands []string
 }
 
-func (s TestConsole) Run(cmd string, opts ...func(*exec.Cmd)) (string, error) {
+func (s *TestConsole) Run(cmd string, opts ...func(*exec.Cmd)) (string, error) {
 	c := &exec.Cmd{}
 	for _, o := range opts {
 		o(c)
 	}
-	Commands = append(Commands, cmd)
-	Commands = append(Commands, c.Args...)
-	if c.Stdin != nil {
-		b, _ := ioutil.ReadAll(c.Stdin)
-		Stdin = string(b)
-	}
+	fmt.Println("Commands:", s.Commands)
+	s.Commands = append(s.Commands, cmd)
+	s.Commands = append(s.Commands, c.Args...)
+	fmt.Println("Commands after append:", s.Commands)
 
 	return "", nil
 }
 
-func Reset() {
-	Commands = []string{}
-	Stdin = ""
+func (s *TestConsole) Reset() {
+	s.Commands = []string{}
 }
-func (s TestConsole) Start(cmd *exec.Cmd, opts ...func(*exec.Cmd)) error {
+func (s *TestConsole) Start(cmd *exec.Cmd, opts ...func(*exec.Cmd)) error {
 	for _, o := range opts {
 		o(cmd)
 	}
-	Commands = append(Commands, cmd.Args...)
-	if cmd.Stdin != nil {
-		b, _ := ioutil.ReadAll(cmd.Stdin)
-		Stdin = string(b)
-	}
+	s.Commands = append(s.Commands, cmd.Args...)
 	return nil
 }
 
-func (s TestConsole) RunTemplate(st []string, template string) error {
+func (s *TestConsole) RunTemplate(st []string, template string) error {
 	var errs error
 
 	for _, svc := range st {


### PR DESCRIPTION
Make sure the test console is using its own copy, we access via pointer, and the reset cleans our own commands copy, instead of the shared one