### PR TITLE
Make datasources log to the proper place

### DIFF
--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -36,8 +36,8 @@ func unique(stringSlice []string) []string {
 }
 
 func DataSources(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
-	var AvailableProviders = []prv.Provider{}
-	var CdromProviders = []prv.Provider{}
+	var AvailableProviders []prv.Provider
+	var CdromProviders []prv.Provider
 
 	if s.DataSources.Providers == nil || len(s.DataSources.Providers) == 0 {
 		return nil
@@ -48,31 +48,31 @@ func DataSources(l logger.Interface, s schema.Stage, fs vfs.FS, console Console)
 	for _, dSProviders := range uniqueProviders {
 		switch {
 		case dSProviders == "aws":
-			AvailableProviders = append(AvailableProviders, prv.NewAWS())
+			AvailableProviders = append(AvailableProviders, prv.NewAWS(l))
 		case dSProviders == "azure":
-			AvailableProviders = append(AvailableProviders, prv.NewAzure())
+			AvailableProviders = append(AvailableProviders, prv.NewAzure(l))
 		case dSProviders == "gcp":
-			AvailableProviders = append(AvailableProviders, prv.NewGCP())
+			AvailableProviders = append(AvailableProviders, prv.NewGCP(l))
 		case dSProviders == "hetzner":
-			AvailableProviders = append(AvailableProviders, prv.NewHetzner())
+			AvailableProviders = append(AvailableProviders, prv.NewHetzner(l))
 		case dSProviders == "openstack":
-			AvailableProviders = append(AvailableProviders, prv.NewOpenstack())
+			AvailableProviders = append(AvailableProviders, prv.NewOpenstack(l))
 		case dSProviders == "packet":
-			AvailableProviders = append(AvailableProviders, prv.NewPacket())
+			AvailableProviders = append(AvailableProviders, prv.NewPacket(l))
 		case dSProviders == "scaleway":
-			AvailableProviders = append(AvailableProviders, prv.NewScaleway())
+			AvailableProviders = append(AvailableProviders, prv.NewScaleway(l))
 		case dSProviders == "vultr":
-			AvailableProviders = append(AvailableProviders, prv.NewVultr())
+			AvailableProviders = append(AvailableProviders, prv.NewVultr(l))
 		case dSProviders == "digitalocean":
-			AvailableProviders = append(AvailableProviders, prv.NewDigitalOcean())
+			AvailableProviders = append(AvailableProviders, prv.NewDigitalOcean(l))
 		case dSProviders == "metaldata":
-			AvailableProviders = append(AvailableProviders, prv.NewMetalData())
+			AvailableProviders = append(AvailableProviders, prv.NewMetalData(l))
 		case dSProviders == "vmware":
-			AvailableProviders = append(AvailableProviders, prv.NewVMware())
+			AvailableProviders = append(AvailableProviders, prv.NewVMware(l))
 		case dSProviders == "cdrom":
-			CdromProviders = append(CdromProviders, prv.ListCDROMs()...)
+			CdromProviders = append(CdromProviders, prv.ListCDROMs(l)...)
 		case dSProviders == "config-drive":
-			CdromProviders = append(CdromProviders, prv.ListConfigDrives()...)
+			CdromProviders = append(CdromProviders, prv.ListConfigDrives(l)...)
 		case dSProviders == "file" && s.DataSources.Path != "":
 			AvailableProviders = append(AvailableProviders, prv.FileProvider(s.DataSources.Path))
 		}

--- a/pkg/plugins/datasourceProviders/provider_aws.go
+++ b/pkg/plugins/datasourceProviders/provider_aws.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path"
 	"time"
+
+	"github.com/mudler/yip/pkg/logger"
 )
 
 const (
@@ -36,11 +38,12 @@ const (
 
 // ProviderAWS is the type implementing the Provider interface for AWS
 type ProviderAWS struct {
+	l logger.Interface
 }
 
 // NewAWS returns a new ProviderAWS
-func NewAWS() *ProviderAWS {
-	return &ProviderAWS{}
+func NewAWS(l logger.Interface) *ProviderAWS {
+	return &ProviderAWS{l}
 }
 
 func (p *ProviderAWS) String() string {

--- a/pkg/plugins/datasourceProviders/provider_cdrom.go
+++ b/pkg/plugins/datasourceProviders/provider_cdrom.go
@@ -20,12 +20,13 @@ package providers
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
+
+	"github.com/mudler/yip/pkg/logger"
 )
 
 // ListCDROMs lists all the cdroms in the system
-func ListCDROMs() []Provider {
+func ListCDROMs(l logger.Interface) []Provider {
 	// UserdataFiles is where to find the user data
 	var userdataFiles = []string{"user-data", "config"}
 	cdroms, err := filepath.Glob(cdromDevs)
@@ -33,17 +34,17 @@ func ListCDROMs() []Provider {
 		// Glob can only error on invalid pattern
 		panic(fmt.Sprintf("Invalid glob pattern: %s", cdromDevs))
 	}
-	log.Printf("cdrom devices to be checked: %v", cdroms)
+	l.Debugf("cdrom devices to be checked: %v", cdroms)
 	// get the devices that match the cloud-init spec
-	cidevs := FindCIs("cidata")
-	log.Printf("CIDATA devices to be checked: %v", cidevs)
+	cidevs := FindCIs("cidata", l)
+	l.Debugf("CIDATA devices to be checked: %v", cidevs)
 	// merge the two, ensuring that the list is unique
 	cdroms = append(cidevs, cdroms...)
 	cdroms = uniqueString(cdroms)
-	log.Printf("unique devices to be checked: %v", cdroms)
+	l.Debugf("unique devices to be checked: %v", cdroms)
 	var providers []Provider
 	for _, device := range cdroms {
-		providers = append(providers, NewProviderCDROM(device, userdataFiles, "CDROM"))
+		providers = append(providers, NewProviderCDROM(device, userdataFiles, "CDROM", l))
 	}
 	return providers
 }

--- a/pkg/plugins/datasourceProviders/provider_gcp.go
+++ b/pkg/plugins/datasourceProviders/provider_gcp.go
@@ -21,12 +21,13 @@ package providers
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/mudler/yip/pkg/logger"
 )
 
 const (
@@ -36,11 +37,12 @@ const (
 
 // ProviderGCP is the type implementing the Provider interface for GCP
 type ProviderGCP struct {
+	l logger.Interface
 }
 
 // NewGCP returns a new ProviderGCP
-func NewGCP() *ProviderGCP {
-	return &ProviderGCP{}
+func NewGCP(l logger.Interface) *ProviderGCP {
+	return &ProviderGCP{l}
 }
 
 func (p *ProviderGCP) String() string {
@@ -67,13 +69,13 @@ func (p *ProviderGCP) Extract() ([]byte, error) {
 	}
 
 	if err := p.handleSSH(); err != nil {
-		log.Printf("GCP: Failed to get ssh data: %s", err)
+		p.l.Errorf("GCP: Failed to get ssh data: %s", err)
 	}
 
 	// Generic userdata
 	userData, err := gcpGet(instance + "attributes/user-data")
 	if err != nil {
-		log.Printf("GCP: Failed to get user-data: %s", err)
+		p.l.Errorf("GCP: Failed to get user-data: %s", err)
 		// This is not an error
 		return nil, nil
 	}

--- a/pkg/plugins/datasourceProviders/provider_openstack_config_drive.go
+++ b/pkg/plugins/datasourceProviders/provider_openstack_config_drive.go
@@ -20,12 +20,13 @@ package providers
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
+
+	"github.com/mudler/yip/pkg/logger"
 )
 
 // ListConfigDrives lists all the cdroms in the system the fill the config-drive standard
-func ListConfigDrives() []Provider {
+func ListConfigDrives(l logger.Interface) []Provider {
 	// UserdataFiles is where to find the user data
 	var userdataFiles = []string{"/openstack/latest/user_data"}
 	cdroms, err := filepath.Glob(cdromDevs)
@@ -33,17 +34,17 @@ func ListConfigDrives() []Provider {
 		// Glob can only error on invalid pattern
 		panic(fmt.Sprintf("Invalid glob pattern: %s", cdromDevs))
 	}
-	log.Printf("cdrom devices to be checked: %v", cdroms)
+	l.Debugf("cdrom devices to be checked: %v", cdroms)
 	// get the devices that match the cloud-init spec
-	cidevs := FindCIs("config-2")
-	log.Printf("CONFIG-2 devices to be checked: %v", cidevs)
+	cidevs := FindCIs("config-2", l)
+	l.Debugf("CONFIG-2 devices to be checked: %v", cidevs)
 	// merge the two, ensuring that the list is unique
 	cdroms = append(cidevs, cdroms...)
 	cdroms = uniqueString(cdroms)
-	log.Printf("unique devices to be checked: %v", cdroms)
+	l.Debugf("unique devices to be checked: %v", cdroms)
 	var providers []Provider
 	for _, device := range cdroms {
-		providers = append(providers, NewProviderCDROM(device, userdataFiles, "CONFIG_DRIVE"))
+		providers = append(providers, NewProviderCDROM(device, userdataFiles, "CONFIG_DRIVE", l))
 	}
 	return providers
 }

--- a/pkg/plugins/datasourceProviders/provider_packet.go
+++ b/pkg/plugins/datasourceProviders/provider_packet.go
@@ -28,6 +28,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/mudler/yip/pkg/logger"
 )
 
 const PacketBaseURL = "https://metadata.platformequinix.com"
@@ -41,11 +43,12 @@ type PacketMetadata struct {
 type ProviderPacket struct {
 	metadata *PacketMetadata
 	err      error
+	l        logger.Interface
 }
 
 // NewPacket returns a new ProviderPacket
-func NewPacket() *ProviderPacket {
-	return &ProviderPacket{}
+func NewPacket(l logger.Interface) *ProviderPacket {
+	return &ProviderPacket{l: l}
 }
 
 func (p *ProviderPacket) String() string {

--- a/pkg/plugins/datasourceProviders/provider_vmware_unsupported.go
+++ b/pkg/plugins/datasourceProviders/provider_vmware_unsupported.go
@@ -20,11 +20,15 @@ limitations under the License.
 
 package providers
 
+import "github.com/mudler/yip/pkg/logger"
+
 // ProviderVMware implements VMware provider interface for unsupported architectures
-type ProviderVMware struct{}
+type ProviderVMware struct {
+	l logger.Interface
+}
 
 // NewVMware returns a new VMware Provider
-func NewVMware() *ProviderVMware {
+func NewVMware(l logger.Interface) *ProviderVMware {
 	return nil
 }
 


### PR DESCRIPTION
Now that we have the datasources here we can pass a proper logger to the them and log at the proper level so we dont pollute the logs with all the logging to stdout