### PR TITLE
feat: Move SSH keys to network stage if required

### DIFF
--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -129,9 +129,9 @@ func (cloudInit) Load(source string, s []byte, fs vfs.FS) (*YipConfig, error) {
 	}
 
 	if networkStage {
-		finalStages["network"] = append(finalStages["network"], sshKeysStage...)
+		finalStages["network"] = sshKeysStage
 	} else {
-		finalStages["boot"] = append(finalStages["boot"], sshKeysStage...)
+		finalStages["boot"][0].SSHKeys = sshKeys
 	}
 
 	result := &YipConfig{Stages: finalStages}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -112,7 +112,7 @@ write_files:
   permissions: "0644"
   owner: "bar"
 `)
-			Expect(len(yipConfig.Stages)).To(Equal(3))
+			Expect(len(yipConfig.Stages)).To(Equal(4))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].UID).To(Equal("1002"))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
 			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"faaapploo", "asdd"}}))
@@ -158,7 +158,8 @@ write_files:
 			Expect(len(yipConfig.Stages)).To(Equal(4))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].UID).To(Equal("1002"))
 			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
-			Expect(len(yipConfig.Stages["boot"][0].SSHKeys)).To(Equal(0))
+			Expect(len(yipConfig.Stages["boot"][0].SSHKeys)).To(Equal(1))
+			Expect(yipConfig.Stages["boot"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"asdd"}}))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
 			Expect(yipConfig.Stages["boot"][0].Files[0].Permissions).To(Equal(uint32(0644)))
 			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal(""))
@@ -169,7 +170,8 @@ write_files:
 			Expect(yipConfig.Stages["boot"][1].Layout.Expand.Size).To(Equal(uint(0)))
 			Expect(yipConfig.Stages["boot"][1].Layout.Device.Path).To(Equal("/"))
 			// if just one key needs network, it should go to the network stage
-			Expect(yipConfig.Stages["network"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"gitlab:test", "asdd"}}))
+			Expect(len(yipConfig.Stages["network"][0].SSHKeys)).To(Equal(1))
+			Expect(yipConfig.Stages["network"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"gitlab:test"}}))
 		})
 	})
 })

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -126,5 +126,50 @@ write_files:
 			Expect(yipConfig.Stages["boot"][1].Layout.Expand.Size).To(Equal(uint(0)))
 			Expect(yipConfig.Stages["boot"][1].Layout.Device.Path).To(Equal("/"))
 		})
+		It("Reads sshkeys to network stage if they require network", Focus, func() {
+			yipConfig := loadstdYip(`#cloud-config
+growpart:
+ devices: ['/']
+stages:
+  test:
+  - environment:
+      foo: bar
+users:
+- name: "bar"
+  passwd: "foo"
+  uid: "1002"
+  lock_passwd: true
+  groups:
+  - sudo
+  ssh_authorized_keys:
+  - gitlab:test
+ssh_authorized_keys:
+  - asdd
+runcmd:
+- foo
+hostname: "bar"
+write_files:
+- encoding: b64
+  content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4
+  path: /foo/bar
+  permissions: "0644"
+  owner: "bar"
+`)
+			Expect(len(yipConfig.Stages)).To(Equal(4))
+			Expect(yipConfig.Stages["boot"][0].Users["bar"].UID).To(Equal("1002"))
+			Expect(yipConfig.Stages["boot"][0].Users["bar"].PasswordHash).To(Equal("foo"))
+			Expect(len(yipConfig.Stages["boot"][0].SSHKeys)).To(Equal(0))
+			Expect(yipConfig.Stages["boot"][0].Files[0].Path).To(Equal("/foo/bar"))
+			Expect(yipConfig.Stages["boot"][0].Files[0].Permissions).To(Equal(uint32(0644)))
+			Expect(yipConfig.Stages["boot"][0].Hostname).To(Equal(""))
+			Expect(yipConfig.Stages["initramfs"][0].Hostname).To(Equal("bar"))
+			Expect(yipConfig.Stages["boot"][0].Commands).To(Equal([]string{"foo"}))
+			Expect(yipConfig.Stages["test"][0].Environment["foo"]).To(Equal("bar"))
+			Expect(yipConfig.Stages["boot"][0].Users["bar"].LockPasswd).To(Equal(true))
+			Expect(yipConfig.Stages["boot"][1].Layout.Expand.Size).To(Equal(uint(0)))
+			Expect(yipConfig.Stages["boot"][1].Layout.Device.Path).To(Equal("/"))
+			// if just one key needs network, it should go to the network stage
+			Expect(yipConfig.Stages["network"][0].SSHKeys).To(Equal(map[string][]string{"bar": {"gitlab:test", "asdd"}}))
+		})
 	})
 })

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -126,7 +126,7 @@ write_files:
 			Expect(yipConfig.Stages["boot"][1].Layout.Expand.Size).To(Equal(uint(0)))
 			Expect(yipConfig.Stages["boot"][1].Layout.Device.Path).To(Equal("/"))
 		})
-		It("Reads sshkeys to network stage if they require network", Focus, func() {
+		It("Reads sshkeys to network stage if they require network", func() {
 			yipConfig := loadstdYip(`#cloud-config
 growpart:
  devices: ['/']


### PR DESCRIPTION
Check if SSH keys are from GitLab or GitHub and move them to the network stage if necessary. This ensures that keys needing network access are handled appropriately during the configuration process.

Fixes https://github.com/kairos-io/kairos/issues/3626