### PR TITLE
Handle more than just nvme devices.

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"unicode"
 	"unsafe"
 
 	"github.com/diskfs/go-diskfs"
@@ -656,17 +657,22 @@ func (dev *Disk) computeFreeSpace() uint64 {
 	return dev.LastS - (OneMiBInBytes/dev.SectorS - 1)
 }
 
+// partitionDevicePath constructs the full device path for a partition.
+// Devices whose names end in a digit (e.g. mmcblk0, nvme0n1, loop0)
+// require a "p" separator before the partition number, while devices
+// ending in a letter (e.g. sda, vda) do not.
+func partitionDevicePath(basedevice string, partNum int) string {
+	if len(basedevice) > 0 && unicode.IsDigit(rune(basedevice[len(basedevice)-1])) {
+		return fmt.Sprintf("%sp%d", basedevice, partNum)
+	}
+	return fmt.Sprintf("%s%d", basedevice, partNum)
+}
+
 // formatPartition formats the given partition using mkfs commands.
 // It expects the disk to be already partitioned.
 // It expects the disk to not be open by any other process.
 func formatPartition(part Partition, basedevice string, console Console) (string, error) {
-	var device string
-	// NVMe devices have a different partition naming scheme
-	if strings.Contains(basedevice, "nvme") {
-		device = fmt.Sprintf("%sp%d", basedevice, part.PartNumber)
-	} else {
-		device = fmt.Sprintf("%s%d", basedevice, part.PartNumber)
-	}
+	device := partitionDevicePath(basedevice, int(part.PartNumber))
 	// We could be also getting here a /dev/disk/by-whatever path, in that case, dont touch it, pass it directly
 	if strings.Contains(basedevice, "/dev/disk/") && strings.Contains(basedevice, "/by-") {
 		device = basedevice
@@ -777,14 +783,8 @@ func (dev *Disk) ExpandLastPartition(size uint64, console Console) error {
 		return fmt.Errorf("could not detect filesystem type: %w", err)
 	}
 
-	var device string
 	partNumber := len(gptTable.Partitions)
-	// NVMe devices have a different partition naming scheme
-	if strings.Contains(dev.Device, "nvme") {
-		device = fmt.Sprintf("%sp%d", dev.Device, partNumber)
-	} else {
-		device = fmt.Sprintf("%s%d", dev.Device, partNumber)
-	}
+	device := partitionDevicePath(dev.Device, partNumber)
 
 	_ = d.Close()
 

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -672,7 +672,7 @@ func partitionDevicePath(basedevice string, partNum int) string {
 // It expects the disk to be already partitioned.
 // It expects the disk to not be open by any other process.
 func formatPartition(part Partition, basedevice string, console Console) (string, error) {
-	device := partitionDevicePath(basedevice, int(part.PartNumber))
+	device := partitionDevicePath(basedevice, part.PartNumber)
 	// We could be also getting here a /dev/disk/by-whatever path, in that case, dont touch it, pass it directly
 	if strings.Contains(basedevice, "/dev/disk/") && strings.Contains(basedevice, "/by-") {
 		device = basedevice
@@ -784,8 +784,14 @@ func (dev *Disk) ExpandLastPartition(size uint64, console Console) error {
 	}
 
 	partNumber := len(gptTable.Partitions)
-	device := partitionDevicePath(dev.Device, partNumber)
 
+	resolvedDevPath, err := filepath.EvalSymlinks(dev.Device)
+	if err != nil {
+		// If resolving symlinks fails, fall back to the original device path
+		resolvedDevPath = dev.Device
+	}
+
+	device := partitionDevicePath(resolvedDevPath, partNumber)
 	_ = d.Close()
 
 	return DefaultGrowFsToMax.GrowFSToMax(device, filesystem)

--- a/pkg/plugins/layout_partition_path_test.go
+++ b/pkg/plugins/layout_partition_path_test.go
@@ -1,0 +1,60 @@
+package plugins
+
+import (
+	"testing"
+)
+
+func TestPartitionDevicePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		device   string
+		partNum  int
+		expected string
+	}{
+		{
+			name:     "sda disk",
+			device:   "/dev/sda",
+			partNum:  1,
+			expected: "/dev/sda1",
+		},
+		{
+			name:     "vda disk",
+			device:   "/dev/vda",
+			partNum:  2,
+			expected: "/dev/vda2",
+		},
+		{
+			name:     "mmcblk device requires p separator",
+			device:   "/dev/mmcblk0",
+			partNum:  4,
+			expected: "/dev/mmcblk0p4",
+		},
+		{
+			name:     "nvme device requires p separator",
+			device:   "/dev/nvme0n1",
+			partNum:  1,
+			expected: "/dev/nvme0n1p1",
+		},
+		{
+			name:     "loop device requires p separator",
+			device:   "/dev/loop0",
+			partNum:  1,
+			expected: "/dev/loop0p1",
+		},
+		{
+			name:     "xvda disk no separator",
+			device:   "/dev/xvda",
+			partNum:  3,
+			expected: "/dev/xvda3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := partitionDevicePath(tt.device, tt.partNum)
+			if got != tt.expected {
+				t.Errorf("partitionDevicePath(%q, %d) = %q, want %q", tt.device, tt.partNum, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/kairos-io/kairos/issues/4082

Used the following Job to test changes. Didn't include test because I didn't know if y'all would want it in the first place.

<details>
<summary>go test file</summary>

```go
package plugins

import (
	"testing"
)

func TestPartitionDevicePath(t *testing.T) {
	tests := []struct {
		name     string
		device   string
		partNum  int
		expected string
	}{
		{
			name:     "sda disk",
			device:   "/dev/sda",
			partNum:  1,
			expected: "/dev/sda1",
		},
		{
			name:     "vda disk",
			device:   "/dev/vda",
			partNum:  2,
			expected: "/dev/vda2",
		},
		{
			name:     "mmcblk device requires p separator",
			device:   "/dev/mmcblk0",
			partNum:  4,
			expected: "/dev/mmcblk0p4",
		},
		{
			name:     "nvme device requires p separator",
			device:   "/dev/nvme0n1",
			partNum:  1,
			expected: "/dev/nvme0n1p1",
		},
		{
			name:     "loop device requires p separator",
			device:   "/dev/loop0",
			partNum:  1,
			expected: "/dev/loop0p1",
		},
		{
			name:     "xvda disk no separator",
			device:   "/dev/xvda",
			partNum:  3,
			expected: "/dev/xvda3",
		},
	}

	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			got := partitionDevicePath(tt.device, tt.partNum)
			if got != tt.expected {
				t.Errorf("partitionDevicePath(%q, %d) = %q, want %q", tt.device, tt.partNum, got, tt.expected)
			}
		})
	}
}
```

</details>

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: yip-test-partition-path
  namespace: jobs
spec:
  backoffLimit: 0
  ttlSecondsAfterFinished: 3600
  template:
    spec:
      restartPolicy: Never
      containers:
        - name: test
          image: golang:1.23
          command:
            - sh
            - -cex
            - |
              git clone --depth 1 https://github.com/mudler/yip.git /work
              cd /work
              git apply /patch/changes.patch
              go test -v -run TestPartitionDevicePath ./pkg/plugins/
          volumeMounts:
            - name: patch
              mountPath: /patch
              readOnly: true
      volumes:
        - name: patch
          configMap:
            name: yip-test-patch
```

Here is the patch referenced:

<details>

<summary> patch file</summary>

```patch
#KUBECONFIG=/home/charlesrod/.kube/config kubectl --context ssdnodes -n jobs create configmap yip-test-patch --from-file=changes.patch=~/yip-combined.patch

diff --git a/pkg/plugins/layout.go b/pkg/plugins/layout.go
index e6fc53d..2c862d2 100644
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"unicode"
 	"unsafe"
 
 	"github.com/diskfs/go-diskfs"
@@ -656,17 +657,22 @@ func (dev *Disk) computeFreeSpace() uint64 {
 	return dev.LastS - (OneMiBInBytes/dev.SectorS - 1)
 }
 
+// partitionDevicePath constructs the full device path for a partition.
+// Devices whose names end in a digit (e.g. mmcblk0, nvme0n1, loop0)
+// require a "p" separator before the partition number, while devices
+// ending in a letter (e.g. sda, vda) do not.
+func partitionDevicePath(basedevice string, partNum int) string {
+	if len(basedevice) > 0 && unicode.IsDigit(rune(basedevice[len(basedevice)-1])) {
+		return fmt.Sprintf("%sp%d", basedevice, partNum)
+	}
+	return fmt.Sprintf("%s%d", basedevice, partNum)
+}
+
 // formatPartition formats the given partition using mkfs commands.
 // It expects the disk to be already partitioned.
 // It expects the disk to not be open by any other process.
 func formatPartition(part Partition, basedevice string, console Console) (string, error) {
-	var device string
-	// NVMe devices have a different partition naming scheme
-	if strings.Contains(basedevice, "nvme") {
-		device = fmt.Sprintf("%sp%d", basedevice, part.PartNumber)
-	} else {
-		device = fmt.Sprintf("%s%d", basedevice, part.PartNumber)
-	}
+	device := partitionDevicePath(basedevice, int(part.PartNumber))
 	// We could be also getting here a /dev/disk/by-whatever path, in that case, dont touch it, pass it directly
 	if strings.Contains(basedevice, "/dev/disk/") && strings.Contains(basedevice, "/by-") {
 		device = basedevice
@@ -777,14 +783,8 @@ func (dev *Disk) ExpandLastPartition(size uint64, console Console) error {
 		return fmt.Errorf("could not detect filesystem type: %w", err)
 	}
 
-	var device string
 	partNumber := len(gptTable.Partitions)
-	// NVMe devices have a different partition naming scheme
-	if strings.Contains(dev.Device, "nvme") {
-		device = fmt.Sprintf("%sp%d", dev.Device, partNumber)
-	} else {
-		device = fmt.Sprintf("%s%d", dev.Device, partNumber)
-	}
+	device := partitionDevicePath(dev.Device, partNumber)
 
 	_ = d.Close()
 
diff --git a/pkg/plugins/layout_partition_path_test.go b/pkg/plugins/layout_partition_path_test.go
new file mode 100644
index 0000000..fe226e6
--- /dev/null
+++ b/pkg/plugins/layout_partition_path_test.go
@@ -0,0 +1,60 @@
+package plugins
+
+import (
+	"testing"
+)
+
+func TestPartitionDevicePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		device   string
+		partNum  int
+		expected string
+	}{
+		{
+			name:     "sda disk",
+			device:   "/dev/sda",
+			partNum:  1,
+			expected: "/dev/sda1",
+		},
+		{
+			name:     "vda disk",
+			device:   "/dev/vda",
+			partNum:  2,
+			expected: "/dev/vda2",
+		},
+		{
+			name:     "mmcblk device requires p separator",
+			device:   "/dev/mmcblk0",
+			partNum:  4,
+			expected: "/dev/mmcblk0p4",
+		},
+		{
+			name:     "nvme device requires p separator",
+			device:   "/dev/nvme0n1",
+			partNum:  1,
+			expected: "/dev/nvme0n1p1",
+		},
+		{
+			name:     "loop device requires p separator",
+			device:   "/dev/loop0",
+			partNum:  1,
+			expected: "/dev/loop0p1",
+		},
+		{
+			name:     "xvda disk no separator",
+			device:   "/dev/xvda",
+			partNum:  3,
+			expected: "/dev/xvda3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := partitionDevicePath(tt.device, tt.partNum)
+			if got != tt.expected {
+				t.Errorf("partitionDevicePath(%q, %d) = %q, want %q", tt.device, tt.partNum, got, tt.expected)
+			}
+		})
+	}
+}
```

</details>