### PR TITLE
feat: Add support for noformat partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,8 +671,8 @@ stages:
          # Size is in MiB. Setting the size to 0 means all available free space.
          # For a good use, we recommend setting all the fields when possible to have a deterministic layout.
          # We especially recommend setting pLabel to avoid recreating partitions if they already exist as all data will be lost on them.
-         # Supported filesystem values: ext2, ext3, ext4, fat, vfat, fat16, fat32, xfs, btrfs, swap.
-         # To create a partition without formatting it, set filesystem to "noformat", "-", or "none".
+          # Supported filesystem values: ext2, ext3, ext4, fat, vfat, fat16, fat32, xfs, btrfs, swap, noformat.
+          # Use filesystem: noformat (or "-" / "none") to create the partition without formatting it.
          add_partitions:
            - fsLabel: COS_STATE
              size: 8192

--- a/README.md
+++ b/README.md
@@ -671,6 +671,8 @@ stages:
          # Size is in MiB. Setting the size to 0 means all available free space.
          # For a good use, we recommend setting all the fields when possible to have a deterministic layout.
          # We especially recommend setting pLabel to avoid recreating partitions if they already exist as all data will be lost on them.
+         # Supported filesystem values: ext2, ext3, ext4, fat, vfat, fat16, fat32, xfs, btrfs, swap.
+         # To create a partition without formatting it, set filesystem to "noformat", "-", or "none".
          add_partitions:
            - fsLabel: COS_STATE
              size: 8192
@@ -682,7 +684,11 @@ stages:
            - fsLabel: COS_GRUB
              size: 512
              filesystem: fat32
-             bootable: true  
+             bootable: true
+           - pLabel: raw_data
+             size: 1024
+             # Use "noformat" (or "-" / "none") to create the partition without formatting it
+             filesystem: noformat
 ```
 
 ### `stages.<stageID>.[<stepN>].unpack_images`

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -352,6 +352,7 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 	}
 
 	partitionsToFormat := make([]Partition, 0)
+	partitionsToInform := make([]Partition, 0)
 
 	// Now go over the parts
 	for index, p := range parts {
@@ -465,6 +466,8 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 		default:
 			partitionsToFormat = append(partitionsToFormat, addPart)
 		}
+		// always add to partitionsToInform so partitions show up
+		partitionsToInform = append(partitionsToInform, addPart)
 
 		// Update dev.Parts to reflect the new partition so we can continue calculating the proper sizes
 		dev.Parts = append(dev.Parts, addPart)
@@ -515,7 +518,7 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 
 	// Only do this if the backend is a device
 	if devInfo.Mode()&os.ModeDevice != 0 {
-		err = kernelAddPartitions(l, d, partitionsToFormat)
+		err = kernelAddPartitions(l, d, partitionsToInform)
 		if err != nil {
 			l.Warnf("Could not inform kernel of new partitions via BLKPG ioctl: %s", err)
 			_ = d.Close()

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -58,6 +58,7 @@ const (
 	Xfs                      = "xfs"
 	Btrfs                    = "btrfs"
 	Swap                     = "swap"
+	NoFormat                 = "noformat"
 )
 
 type Disk struct {
@@ -432,6 +433,8 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 			}
 		case Swap:
 			fsType = gpt.LinuxSwap
+		case "-", "none", NoFormat:
+			fsType = gpt.LinuxFilesystem
 		default:
 			_ = d.Close()
 			return fmt.Errorf("unsupported filesystem type: %s", p.FileSystem)
@@ -456,7 +459,13 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 			FSLabel:    p.FSLabel,
 			PartNumber: len(gptTable.Partitions), // 1-indexed
 		}
-		partitionsToFormat = append(partitionsToFormat, addPart)
+		switch p.FileSystem {
+		case "-", "none", NoFormat:
+			l.Debugf("Skipping formatting for partition %d", len(gptTable.Partitions)+1)
+		default:
+			partitionsToFormat = append(partitionsToFormat, addPart)
+		}
+
 		// Update dev.Parts to reflect the new partition so we can continue calculating the proper sizes
 		dev.Parts = append(dev.Parts, addPart)
 		if p.FSLabel != "" {

--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -461,7 +461,7 @@ func (dev *Disk) AddPartitions(parts []schema.Partition, l logger.Interface, con
 		}
 		switch p.FileSystem {
 		case "-", "none", NoFormat:
-			l.Debugf("Skipping formatting for partition %d", len(gptTable.Partitions)+1)
+			l.Debugf("Skipping formatting for partition %d", len(gptTable.Partitions))
 		default:
 			partitionsToFormat = append(partitionsToFormat, addPart)
 		}

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -647,7 +647,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 			err := Layout(l, schema.Stage{
 				Layout: schema.Layout{
 					Device: &schema.Device{Path: devicePath},
-					Parts:  []schema.Partition{{PLabel: label, Size: 100, FileSystem: "noformat"}},
+					Parts:  []schema.Partition{{PLabel: label, Size: 100, FileSystem: NoFormat}},
 				},
 			}, fs, testConsole)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -710,7 +710,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 				Layout: schema.Layout{
 					Device: &schema.Device{Path: devicePath},
 					Parts: []schema.Partition{
-						{PLabel: "NOFMT", Size: 100, FileSystem: "noformat"},
+						{PLabel: "NOFMT", Size: 100, FileSystem: NoFormat},
 						{PLabel: "DATA", Size: 100, FileSystem: "ext4"},
 					},
 				},

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -61,11 +61,11 @@ var _ = Describe("computeFreeSpace and CheckDiskFreeSpaceMiB", Label("layout"), 
 		// 10 GiB disk, 512-byte sectors
 		const sectorSize = uint64(512)
 		const diskBytes = uint64(10 * 1024 * 1024 * 1024) // 10 GiB
-		totalSectors := diskBytes / sectorSize              // 20971520
+		totalSectors := diskBytes / sectorSize            // 20971520
 
 		// Partition starting at 1 MiB, spanning 4 GiB
 		partStartSectors := uint64(1024 * 1024 / sectorSize) // 2048
-		partSizeBytes := uint64(4 * 1024 * 1024 * 1024)       // 4 GiB in bytes
+		partSizeBytes := uint64(4 * 1024 * 1024 * 1024)      // 4 GiB in bytes
 		partEndSectors := partStartSectors + (partSizeBytes / sectorSize) - 1
 
 		dev := Disk{
@@ -637,6 +637,96 @@ var _ = Describe("Layout", Label("layout"), func() {
 			}, fs, testConsole)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("empty"))
+		})
+		It("Adds a noformat partition without calling mkfs", func() {
+			testConsole := console.New()
+			testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+			// Intentionally do not register any mkfs command. The mock console
+			// fails the test if any unregistered command is run, so this asserts
+			// that no formatting tool is invoked for a noformat partition.
+			err := Layout(l, schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Path: devicePath},
+					Parts:  []schema.Partition{{PLabel: label, Size: 100, FileSystem: "noformat"}},
+				},
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			disk, err := fileBackend.OpenFromPath(rawDevicePath, true)
+			Expect(err).ToNot(HaveOccurred())
+			defer disk.Close()
+			table, err := gpt.Read(disk, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(table.Type()).To(Equal("gpt"))
+			Expect(table.Partitions).To(HaveLen(1))
+			Expect(table.Partitions[0].Name).To(Equal(label))
+			Expect(table.Partitions[0].Size).To(Equal(uint64(100*1024*1024) - reservedSectorsInBytes))
+		})
+		It("Adds a partition with FileSystem=\"-\" without calling mkfs", func() {
+			testConsole := console.New()
+			testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+			err := Layout(l, schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Path: devicePath},
+					Parts:  []schema.Partition{{PLabel: label, Size: 100, FileSystem: "-"}},
+				},
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			disk, err := fileBackend.OpenFromPath(rawDevicePath, true)
+			Expect(err).ToNot(HaveOccurred())
+			defer disk.Close()
+			table, err := gpt.Read(disk, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(table.Partitions).To(HaveLen(1))
+			Expect(table.Partitions[0].Name).To(Equal(label))
+		})
+		It("Adds a partition with FileSystem=\"none\" without calling mkfs", func() {
+			testConsole := console.New()
+			testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+			err := Layout(l, schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Path: devicePath},
+					Parts:  []schema.Partition{{PLabel: label, Size: 100, FileSystem: "none"}},
+				},
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			disk, err := fileBackend.OpenFromPath(rawDevicePath, true)
+			Expect(err).ToNot(HaveOccurred())
+			defer disk.Close()
+			table, err := gpt.Read(disk, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(table.Partitions).To(HaveLen(1))
+			Expect(table.Partitions[0].Name).To(Equal(label))
+		})
+		It("Mixes formatted and noformat partitions: only formatted ones invoke mkfs", func() {
+			testConsole := console.New()
+			testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+			// Only one mkfs call expected, for the ext4 partition. The noformat
+			// partition must not produce any mkfs invocation.
+			testConsole.AddCmd(console.CmdMock{Cmd: fmt.Sprintf("mkfs.ext4 /tmp/go-vfs-.*%s2", devicePath), UseRegexp: true})
+			err := Layout(l, schema.Stage{
+				Layout: schema.Layout{
+					Device: &schema.Device{Path: devicePath},
+					Parts: []schema.Partition{
+						{PLabel: "NOFMT", Size: 100, FileSystem: "noformat"},
+						{PLabel: "DATA", Size: 100, FileSystem: "ext4"},
+					},
+				},
+			}, fs, testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			disk, err := fileBackend.OpenFromPath(rawDevicePath, true)
+			Expect(err).ToNot(HaveOccurred())
+			defer disk.Close()
+			table, err := gpt.Read(disk, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(table.Partitions).To(HaveLen(2))
+			Expect(table.Partitions[0].Name).To(Equal("NOFMT"))
+			Expect(table.Partitions[1].Name).To(Equal("DATA"))
+			// All queued commands consumed (no mkfs call was skipped or duplicated).
+			Expect(testConsole.Cmds.Len()).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
- Introduced a new filesystem type "noformat" to handle partitions without formatting.
- Updated partition handling logic to skip formatting for partitions with filesystem set to "noformat", "-", or "none".
- Added tests to ensure no formatting occurs for noformat partitions and that mixed partition types are handled correctly.