### PR TITLE
fix(layout): keep expanded partitions inside the last usable sector

### DIFF
--- a/pkg/plugins/layout.go
+++ b/pkg/plugins/layout.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"unicode"
@@ -48,17 +49,21 @@ const (
 	xfsMagic                 = "XFSB"
 	swapMagicSignature       = "SWAPSPACE2"
 	OneMiBInBytes            = 1024 * 1024
-	Ext4                     = "ext4"
-	Ext3                     = "ext3"
-	Ext2                     = "ext2"
-	Fat                      = "fat"
-	Vfat                     = "vfat"
-	Fat32                    = "fat32"
-	Fat16                    = "fat16"
-	Xfs                      = "xfs"
-	Btrfs                    = "btrfs"
-	Swap                     = "swap"
-	NoFormat                 = "noformat"
+	// gptTailSectors is the space at the end of the disk reserved for the backup
+	// GPT: 1 sector for the header plus 32 sectors for the 128 entries partition
+	// array. The last sector a partition may use is therefore LastS-34.
+	gptTailSectors = 34
+	Ext4           = "ext4"
+	Ext3           = "ext3"
+	Ext2           = "ext2"
+	Fat            = "fat"
+	Vfat           = "vfat"
+	Fat32          = "fat32"
+	Fat16          = "fat16"
+	Xfs            = "xfs"
+	Btrfs          = "btrfs"
+	Swap           = "swap"
+	NoFormat       = "noformat"
 )
 
 type Disk struct {
@@ -300,12 +305,24 @@ func Layout(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) erro
 
 	l.Debugf("Checking for layout expansion on device %s", dev.Device)
 	if s.Layout.Expand != nil {
+		// Expansion always grows the last partition of the disk. When the device
+		// was selected by label, make sure that label is on the last partition,
+		// otherwise we would silently grow a different partition over it.
+		if label := strings.TrimSpace(s.Layout.Device.Label); label != "" {
+			isLast, err := labelIsOnLastPartition(dev, label, fs)
+			if err != nil {
+				l.Debugf("Could not tell which partition holds label %s (%s), expanding the last partition", label, err.Error())
+			} else if !isLast {
+				l.Warnf("Label %s is not on the last partition of %s, skipping expansion: it would grow the last partition instead", label, dev.Device)
+				return nil
+			}
+		}
 		if s.Layout.Expand.Size == 0 {
 			l.Debug("Extending last partition to max space")
 		} else {
 			l.Debugf("Extending last partition to %d MiB", s.Layout.Expand.Size)
 		}
-		err := dev.ExpandLastPartition(s.Layout.Expand.Size, console)
+		err := dev.ExpandLastPartition(l, s.Layout.Expand.Size, console)
 		if err != nil {
 			l.Error(err.Error())
 			return err
@@ -631,6 +648,47 @@ func FindDiskFromLabel(label string, fs vfs.FS) (Disk, error) {
 	}, nil
 }
 
+// labelIsOnLastPartition reports whether the filesystem label lives on the last
+// partition of the disk. Returns an error when the label cannot be mapped to a
+// partition number, for example when it resolves to an image file rather than to
+// a /dev/<disk><number> block device.
+func labelIsOnLastPartition(dev Disk, label string, fs vfs.FS) (bool, error) {
+	if len(dev.Parts) == 0 {
+		return false, errors.New("no partitions found on device")
+	}
+	path, err := fs.RawPath(filepath.Join("/dev/disk/by-label", label))
+	if err != nil {
+		return false, fmt.Errorf("could not resolve raw path for label %q: %w", label, err)
+	}
+	partDev, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false, fmt.Errorf("resolve label %q: %w", label, err)
+	}
+	partNumber, err := PartitionNumberFromDevice(partDev)
+	if err != nil {
+		return false, err
+	}
+	return partNumber == dev.Parts[len(dev.Parts)-1].PartNumber, nil
+}
+
+// PartitionNumberFromDevice extracts the partition number out of a partition
+// device path, handling both the /dev/sda3 and the /dev/nvme0n1p3 conventions.
+func PartitionNumberFromDevice(devPath string) (int, error) {
+	base := filepath.Base(devPath)
+	digits := len(base)
+	for digits > 0 && unicode.IsDigit(rune(base[digits-1])) {
+		digits--
+	}
+	if digits == len(base) || digits == 0 {
+		return 0, fmt.Errorf("no partition number in device %q", base)
+	}
+	number, err := strconv.Atoi(base[digits:])
+	if err != nil {
+		return 0, fmt.Errorf("no partition number in device %q: %w", base, err)
+	}
+	return number, nil
+}
+
 func parentDiskFromBlockDev(devPath string) (string, error) {
 	// First check if its some kind of image file instead of a block device
 	// naively check if the path contains /dev/
@@ -705,7 +763,7 @@ func formatPartition(part Partition, basedevice string, console Console) (string
 	return mkfs.Apply(console)
 }
 
-func (dev *Disk) ExpandLastPartition(size uint64, console Console) error {
+func (dev *Disk) ExpandLastPartition(l logger.Interface, size uint64, console Console) error {
 	if len(dev.Parts) == 0 {
 		return errors.New("no partition to expand")
 	}
@@ -782,9 +840,18 @@ func (dev *Disk) ExpandLastPartition(size uint64, console Console) error {
 	}
 
 	if size == 0 {
-		part.End = dev.LastS - 1
+		// requestedSize already accounts for the reserved tail
+		part.End = part.Start + (requestedSize / dev.SectorS) - 1
 	} else {
 		part.End = part.Start + MiBToSectors(size, dev.SectorS) - 1
+	}
+	// The tail of the disk belongs to the backup GPT (header + partition array).
+	// A partition ending past the last usable sector corrupts the table: the
+	// kernel and the on-disk GPT then disagree and udev stops creating the
+	// by-partlabel symlinks. Cap the partition instead of overrunning it.
+	if lastUsableSector := dev.LastS - gptTailSectors; part.End > lastUsableSector {
+		l.Warnf("Requested size ends at sector %d, past the last usable sector %d, capping the partition to it", part.End, lastUsableSector)
+		part.End = lastUsableSector
 	}
 	// We have to set Size to 0 so the GPT library recalculates it
 	part.Size = 0

--- a/pkg/plugins/layout_test.go
+++ b/pkg/plugins/layout_test.go
@@ -23,6 +23,23 @@ import (
 // This are the reserved sectors in a GPT partition table (2048 sectors of 512 bytes)
 const reservedSectorsInBytes = uint64(2048 * diskfs.SectorSize512)
 
+// Test disks are 1GiB plus the 1MiB reserved at the start.
+const testDiskSize = uint64(1024*1024*1024) + reservedSectorsInBytes
+
+// The tail of a GPT disk belongs to the backup GPT: 1 sector for the header plus
+// 32 sectors for the 128 entries partition array. The last sector a partition may
+// use is therefore LastS-34, and an expansion asking for more is capped to it.
+const gptTailSectors = uint64(34)
+
+// maxFixedExpandSize is what a partition starting at 1MiB ends up with when it
+// asks for a fixed size that would reach past the end of the disk: everything up
+// to (and including) the last usable sector.
+const maxFixedExpandSize = (testDiskSize/uint64(diskfs.SectorSize512) - gptTailSectors - 2048 + 1) * uint64(diskfs.SectorSize512)
+
+// maxExpandToAllSize is what "expand to all remaining space" (size 0) yields: the
+// disk minus the 1MiB start offset and the 1MiB reserved tail.
+const maxExpandToAllSize = uint64(1024*1024*1024) - reservedSectorsInBytes
+
 // This tests run against a real disk image file created in a temp folder
 // The mkfs calls are the ones mocked as we cannot run mkfs against a file image partition without
 // having to mount it into a loop device and so on, but on a real device these calls would run as expected
@@ -390,7 +407,8 @@ var _ = Describe("Layout", Label("layout"), func() {
 				},
 			}, fs, testConsole)
 			Expect(err).Should(BeNil())
-			// Now check if the partition size is now 1024MiB
+			// 1024MiB does not fit once the backup GPT tail is reserved, so the
+			// partition is capped at the last usable sector instead of overrunning it
 			disk2, err := fileBackend.OpenFromPath(rawDevicePath, true)
 			defer disk2.Close()
 			table2, err := gpt.Read(disk2, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
@@ -400,7 +418,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 			Expect(table2.Partitions).To(HaveLen(1))
 			deviceLabel = table2.Partitions[0].Name
 			Expect(deviceLabel).To(Equal("FAKELABEL"))
-			Expect(table2.Partitions[0].Size).To(Equal(uint64(1024 * 1024 * 1024)))
+			Expect(table2.Partitions[0].Size).To(Equal(maxFixedExpandSize))
 
 		})
 		It("Expands last partition to take all space", func() {
@@ -454,7 +472,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 			Expect(table2.Partitions).To(HaveLen(1))
 			deviceLabel = table2.Partitions[0].Name
 			Expect(deviceLabel).To(Equal("FAKELABEL"))
-			Expect(table2.Partitions[0].Size).To(Equal(uint64(1024 * 1024 * 1024)))
+			Expect(table2.Partitions[0].Size).To(Equal(maxExpandToAllSize))
 
 		})
 		It("Expands last partition after creating the partitions", func() {
@@ -481,7 +499,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 			Expect(table.Partitions).To(HaveLen(1))
 			deviceLabel = table.Partitions[0].Name
 			Expect(deviceLabel).To(Equal("FAKELABEL"))
-			Expect(table.Partitions[0].Size).To(Equal(uint64(1024 * 1024 * 1024)))
+			Expect(table.Partitions[0].Size).To(Equal(maxFixedExpandSize))
 
 		})
 		It("Expands last partition with XFS fs", func() {
@@ -508,7 +526,7 @@ var _ = Describe("Layout", Label("layout"), func() {
 			Expect(table.Partitions).To(HaveLen(1))
 			deviceLabel = table.Partitions[0].Name
 			Expect(deviceLabel).To(Equal("FAKELABEL"))
-			Expect(table.Partitions[0].Size).To(Equal(uint64(1024 * 1024 * 1024)))
+			Expect(table.Partitions[0].Size).To(Equal(maxFixedExpandSize))
 
 		})
 		It("Fails to expand last partition, if there is not enough space left", func() {
@@ -728,5 +746,93 @@ var _ = Describe("Layout", Label("layout"), func() {
 			// All queued commands consumed (no mkfs call was skipped or duplicated).
 			Expect(testConsole.Cmds.Len()).To(Equal(0))
 		})
+	})
+})
+
+var _ = Describe("ExpandLastPartition GPT tail", Label("layout"), func() {
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(io.Discard)
+
+	It("keeps the expanded partition inside the last usable sector", func() {
+		fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
+		Expect(err).Should(BeNil())
+		defer cleanup()
+		rawDevicePath, err := fs.RawPath("/test.img")
+		Expect(err).Should(BeNil())
+		fileDisk, err := fileBackend.CreateFromPath(rawDevicePath, 1*1024*1024*1024+int64(reservedSectorsInBytes))
+		Expect(err).To(BeNil())
+		Expect(fileDisk.Close()).ToNot(HaveOccurred())
+		d, err := diskfs.Open(rawDevicePath)
+		Expect(err).To(BeNil())
+		Expect(d.Partition(&gpt.Table{
+			ProtectiveMBR:      true,
+			LogicalSectorSize:  int(d.LogicalBlocksize),
+			PhysicalSectorSize: int(d.PhysicalBlocksize),
+		})).To(Succeed())
+		Expect(d.Close()).ToNot(HaveOccurred())
+
+		DefaultFilesystemDetector = MockFilesystemDetector{func(part *gpt.Partition, d *disk.Disk) (string, error) {
+			return "ext4", nil
+		}}
+		DefaultGrowFsToMax = MockGrowFSToMax{func(device string, filesystem string) error { return nil }}
+
+		testConsole := console.New()
+		testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+		testConsole.AddCmd(console.CmdMock{Cmd: "mkfs.ext2 /tmp/go-vfs-.*/test.img1", UseRegexp: true})
+		testConsole.AddCmd(console.CmdMock{Cmd: "udevadm trigger && udevadm settle"})
+		Expect(Layout(l, schema.Stage{
+			Layout: schema.Layout{
+				Device: &schema.Device{Path: "/test.img"},
+				Parts:  []schema.Partition{{PLabel: "FAKELABEL", Size: 512}},
+			},
+		}, fs, testConsole)).To(Succeed())
+
+		Expect(Layout(l, schema.Stage{
+			Layout: schema.Layout{
+				Device: &schema.Device{Path: "/test.img"},
+				Expand: &schema.Expand{},
+			},
+		}, fs, testConsole)).To(Succeed())
+
+		disk2, err := fileBackend.OpenFromPath(rawDevicePath, true)
+		Expect(err).ToNot(HaveOccurred())
+		defer disk2.Close()
+		table, err := gpt.Read(disk2, int(diskfs.SectorSize512), int(diskfs.SectorSize512))
+		Expect(err).ToNot(HaveOccurred())
+
+		diskSectors := uint64(1*1024*1024*1024+int64(reservedSectorsInBytes)) / 512
+		// GPT reserves the last sector for the backup header plus 32 sectors for
+		// the backup partition array: the last usable sector is diskSectors-34.
+		lastUsable := diskSectors - 34
+		Expect(table.Partitions[0].End).To(BeNumerically("<=", lastUsable),
+			fmt.Sprintf("partition ends at %d, past last usable sector %d (overlaps backup GPT by %d sectors)",
+				table.Partitions[0].End, lastUsable, table.Partitions[0].End-lastUsable))
+	})
+})
+
+var _ = Describe("PartitionNumberFromDevice", Label("layout"), func() {
+	It("parses the sdaN convention", func() {
+		n, err := PartitionNumberFromDevice("/dev/sda3")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(3))
+	})
+	It("parses the nvme0n1pN convention", func() {
+		n, err := PartitionNumberFromDevice("/dev/nvme0n1p12")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(12))
+	})
+	It("parses the mmcblk0pN convention", func() {
+		n, err := PartitionNumberFromDevice("/dev/mmcblk0p2")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(2))
+	})
+	It("fails on a whole disk with no partition number", func() {
+		_, err := PartitionNumberFromDevice("/dev/sda")
+		Expect(err).To(HaveOccurred())
+	})
+	It("fails on an image file", func() {
+		_, err := PartitionNumberFromDevice("/tmp/whatever/test.img")
+		Expect(err).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Expanding to max set the partition End to LastS-1, the very last sector of the disk. The tail of a GPT disk belongs to the backup GPT (1 header sector plus 32 sectors of partition array), so the partition overran it by 33 sectors and left an inconsistent table: the kernel and the on-disk GPT disagree on the last partition and udev stops creating its by-partlabel symlink.

Derive End from the requestedSize the function already computes with a reserved tail, and cap any expansion that would still end past the last usable sector instead of overrunning it.

Also skip the expansion when the device was selected by label and that label is not on the last partition. Expansion always grows the last partition, so a layout selecting COS_PERSISTENT on a disk where another partition comes last would silently grow that other partition over it.

ExpandLastPartition now takes a logger so the capping can be reported.

Refs kairos-io/kairos#4257