### PR TITLE
feat(users): allow pinning gid alongside uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ In case the user is already existing, the password only will be overwritten.
 - **system**: Create the user as a system user. No home directory will be created.
 - **no-log-init**: Boolean. Skip initialization of lastlog and faillog databases.
 - **shell**: User's login shell.
+- **uid**: Numeric user id to assign. When set, the user is created with this exact uid and no free-uid search or home-directory-owner reuse is performed. Useful on immutable systems where `/etc/passwd` is regenerated on every boot but `/home` is persisted, to keep file ownership stable across boots.
+- **gid**: Numeric group id to assign to the user's primary group. When set, the primary group is created with this exact gid. Same rationale as `uid` — pin it to keep group ownership stable across regenerations of `/etc/group`. If a home directory that the user owns already exists with a different gid, both gids will be present in `/etc/group` (Linux allows duplicate gids) so pre-existing file ownership is not silently rewritten.
 
 ```yaml
 stages:

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ In case the user is already existing, the password only will be overwritten.
 - **no-log-init**: Boolean. Skip initialization of lastlog and faillog databases.
 - **shell**: User's login shell.
 - **uid**: Numeric user id to assign. When set, the user is created with this exact uid and no free-uid search or home-directory-owner reuse is performed. Useful on immutable systems where `/etc/passwd` is regenerated on every boot but `/home` is persisted, to keep file ownership stable across boots.
-- **gid**: Numeric group id to assign to the user's primary group. When set, the primary group is created with this exact gid. Same rationale as `uid` — pin it to keep group ownership stable across regenerations of `/etc/group`. If a home directory that the user owns already exists with a different gid, both gids will be present in `/etc/group` (Linux allows duplicate gids) so pre-existing file ownership is not silently rewritten.
+- **gid**: Numeric group id for the user's own primary group. When set (and `primary_group` is empty) the primary group is created with this exact gid. Same rationale as `uid` — pin it to keep group ownership stable across regenerations of `/etc/group`. If `primary_group` is set as well, the existing group's numeric gid wins and `gid` is ignored — rewriting a well-known group's gid would silently break file ownership on the host. Leave `primary_group` empty to pin the gid of the auto-created user group.
 
 ```yaml
 stages:

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -219,7 +219,7 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 		if err != nil {
 			return errors.Wrap(err, "invalid gid defined")
 		}
-	} else if _, hgid, ok := DefaultHomeDirResolver.Resolve(fs, resolveHomedir(fs, u)); ok && !groupGIDInUse(etcgroup, hgid) {
+	} else if _, hgid, ok := DefaultHomeDirResolver.Resolve(fs, resolveHomedir(fs, u)); ok {
 		// The user is being (re)created but its home directory already exists
 		// (e.g. an immutable OS that regenerates /etc/{passwd,group} on every
 		// boot while /home is persisted). Reuse the gid that owns the home

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -119,7 +119,7 @@ func resolveHomedir(fs vfs.FS, u schema.User) string {
 // swapping their uids on the next boot. See:
 // https://github.com/kairos-io/kairos/issues/2949
 func hasDeterministicUID(fs vfs.FS, u schema.User) bool {
-	if u.UID != "" {
+	if u.UID != "" || u.GID != "" {
 		return true
 	}
 	if etcpasswd, err := fs.RawPath("/etc/passwd"); err == nil {
@@ -194,7 +194,17 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 	primaryGroup := u.Name
 
 	gid := -1 // -1 instructs entities to find the next free id and assign it
-	if u.PrimaryGroup != "" {
+	if u.GID != "" {
+		// Explicit gid: use it verbatim, same semantics as an explicit uid.
+		// This wins over primary_group lookup and home directory reuse.
+		gid, err = strconv.Atoi(u.GID)
+		if err != nil {
+			return errors.Wrap(err, "invalid gid defined")
+		}
+		if u.PrimaryGroup != "" {
+			primaryGroup = u.PrimaryGroup
+		}
+	} else if u.PrimaryGroup != "" {
 		gr, err := osuser.LookupGroup(u.PrimaryGroup)
 		if err != nil {
 			return errors.Wrap(err, "could not resolve primary group of user")
@@ -343,12 +353,12 @@ func User(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error 
 	sort.Strings(names)
 
 	// Split users into two groups, preserving alphabetical order within each:
-	// those whose uid is already deterministic (explicit uid, already present in
-	// /etc/passwd, or with an existing home directory) and those that need a
-	// generated uid. Deterministic users must be processed first so that a brand
-	// new user cannot grab the uid that belongs to an existing user's home
-	// directory before that user is (re)created, which would swap their uids and
-	// corrupt file ownership across boots.
+	// those whose uid/gid is already deterministic (explicit uid or gid, already
+	// present in /etc/passwd, or with an existing home directory) and those
+	// that need a generated id. Deterministic users must be processed first so
+	// that a brand new user cannot grab the id that belongs to an existing
+	// user's home directory before that user is (re)created, which would swap
+	// their ids and corrupt file ownership across boots.
 	// https://github.com/kairos-io/kairos/issues/2949
 	deterministic := make([]string, 0, len(names))
 	generated := make([]string, 0, len(names))

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -206,7 +206,10 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 		if err != nil {
 			return errors.Wrap(err, "could not resolve primary group of user")
 		}
-		gid, _ = strconv.Atoi(gr.Gid)
+		gid, err = strconv.Atoi(gr.Gid)
+		if err != nil {
+			return errors.Wrap(err, "invalid gid returned for primary group")
+		}
 		primaryGroup = u.PrimaryGroup
 	} else if u.GID != "" {
 		// Explicit gid without an explicit primary_group: create the user's own

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -119,7 +119,7 @@ func resolveHomedir(fs vfs.FS, u schema.User) string {
 // swapping their uids on the next boot. See:
 // https://github.com/kairos-io/kairos/issues/2949
 func hasDeterministicUID(fs vfs.FS, u schema.User) bool {
-	if u.UID != "" || u.GID != "" {
+	if u.UID != "" {
 		return true
 	}
 	if etcpasswd, err := fs.RawPath("/etc/passwd"); err == nil {
@@ -194,23 +194,28 @@ func createUser(fs vfs.FS, u schema.User, console Console) error {
 	primaryGroup := u.Name
 
 	gid := -1 // -1 instructs entities to find the next free id and assign it
-	if u.GID != "" {
-		// Explicit gid: use it verbatim, same semantics as an explicit uid.
-		// This wins over primary_group lookup and home directory reuse.
-		gid, err = strconv.Atoi(u.GID)
-		if err != nil {
-			return errors.Wrap(err, "invalid gid defined")
-		}
-		if u.PrimaryGroup != "" {
-			primaryGroup = u.PrimaryGroup
-		}
-	} else if u.PrimaryGroup != "" {
+	if u.PrimaryGroup != "" {
+		// An explicit primary_group names an existing system group. Look up its
+		// numeric gid and reuse it. Explicit u.GID is intentionally ignored in
+		// this branch — rewriting a well-known group's gid (e.g. wheel, docker)
+		// would silently break every file already owned by that gid, which is
+		// almost never what the caller wants. If the intent is to create the
+		// user's own group with a pinned gid, leave primary_group empty and set
+		// gid instead.
 		gr, err := osuser.LookupGroup(u.PrimaryGroup)
 		if err != nil {
 			return errors.Wrap(err, "could not resolve primary group of user")
 		}
 		gid, _ = strconv.Atoi(gr.Gid)
 		primaryGroup = u.PrimaryGroup
+	} else if u.GID != "" {
+		// Explicit gid without an explicit primary_group: create the user's own
+		// primary group (named after the user) with this exact gid. Same
+		// semantics as an explicit uid — wins over home-directory gid reuse.
+		gid, err = strconv.Atoi(u.GID)
+		if err != nil {
+			return errors.Wrap(err, "invalid gid defined")
+		}
 	} else if _, hgid, ok := DefaultHomeDirResolver.Resolve(fs, resolveHomedir(fs, u)); ok && !groupGIDInUse(etcgroup, hgid) {
 		// The user is being (re)created but its home directory already exists
 		// (e.g. an immutable OS that regenerates /etc/{passwd,group} on every

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -219,6 +219,93 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 
 		})
 
+		It("set UID and GID explicitly", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = User(l, schema.Stage{
+				Users: map[string]schema.User{"foo": {
+					PasswordHash: `$fkekofe`,
+					UID:          "5000",
+					GID:          "6000",
+					Homedir:      "/run/foo",
+					Shell:        "/bin/bash",
+				}},
+			}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			group, err := fs.ReadFile("/etc/group")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(group)).Should(Equal("foo:x:6000:foo\n"))
+
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			list := xpasswd.NewUserList()
+			list.SetPath(passdRaw)
+			Expect(list.Load()).ShouldNot(HaveOccurred())
+			foo := list.Get("foo")
+			Expect(foo).ToNot(BeNil())
+			Expect(foo.UID()).To(Equal(5000))
+			gid, err := foo.GID()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(gid).To(Equal(6000))
+		})
+
+		It("set GID without UID assigns explicit gid and generated uid", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = User(l, schema.Stage{
+				Users: map[string]schema.User{"foo": {
+					PasswordHash: `$fkekofe`,
+					GID:          "7000",
+					Homedir:      "/run/foo",
+					Shell:        "/bin/bash",
+				}},
+			}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			group, err := fs.ReadFile("/etc/group")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(group)).Should(Equal("foo:x:7000:foo\n"))
+
+			passdRaw, _ := fs.RawPath("/etc/passwd")
+			list := xpasswd.NewUserList()
+			list.SetPath(passdRaw)
+			Expect(list.Load()).ShouldNot(HaveOccurred())
+			foo := list.Get("foo")
+			Expect(foo).ToNot(BeNil())
+			gid, err := foo.GID()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(gid).To(Equal(7000))
+		})
+
+		It("returns an error when gid is not a number", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = User(l, schema.Stage{
+				Users: map[string]schema.User{"foo": {
+					PasswordHash: `$fkekofe`,
+					GID:          "notanumber",
+					Homedir:      "/run/foo",
+				}},
+			}, fs, &testConsole)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("invalid gid defined"))
+		})
+
 		It("edits already existing user password", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": `foo:$6$rfBd56ti$7juhxebonsy.GiErzyxZPkbm.U4lUlv/59D2pvFqlbjVqyJP5f4VgP.EX3FKAeGTAr.GVf0jQmy9BXAZL5mNJ1:18820::::::
@@ -639,6 +726,42 @@ rancher:$6$2SMtYvSg$wL/zzuT4m3uYkHWO1Rl4x5U6BeGu9IfzIafueinxnNgLFHI34En35gu9evtl
 			// so that file ownership stays consistent across boots.
 			Expect(a.GID()).To(Equal(1000))
 			Expect(c.GID()).To(Equal(1001))
+		})
+
+		// Both an explicit gid AND a persistent home directory gid must be
+		// respected as-is — neither can be silently reassigned, or the user
+		// whose files already carry that gid would lose ownership. When they
+		// coincide the two users share a numeric gid; Linux permits duplicate
+		// gids and both users keep file access to their own home directory.
+		It("respects both explicit gid and home-directory gid even when they collide", func() {
+			owners := map[string][2]int{
+				"/home/yiptestuser2a": {2000, 2000},
+			}
+			original := DefaultHomeDirResolver
+			DefaultHomeDirResolver = fakeHomeDirResolver{owners: owners}
+			defer func() { DefaultHomeDirResolver = original }()
+
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = User(l, schema.Stage{
+				Users: map[string]schema.User{
+					"yiptestuser2a": {PasswordHash: `$fkekofe`},                 // home dir gid=2000, must be reused
+					"yiptestuser2b": {PasswordHash: `$fkekofe`, GID: "2000"},    // explicit gid=2000, must be honored
+				},
+			}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			group, err := fs.ReadFile("/etc/group")
+			Expect(err).ShouldNot(HaveOccurred())
+			// Both users end up with gid 2000 — neither loses its established id.
+			Expect(string(group)).Should(ContainSubstring("yiptestuser2a:x:2000:"))
+			Expect(string(group)).Should(ContainSubstring("yiptestuser2b:x:2000:"))
 		})
 	})
 })

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -242,9 +242,9 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(string(group)).Should(Equal("foo:x:6000:foo\n"))
 
-			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwdRaw, _ := fs.RawPath("/etc/passwd")
 			list := xpasswd.NewUserList()
-			list.SetPath(passdRaw)
+			list.SetPath(passwdRaw)
 			Expect(list.Load()).ShouldNot(HaveOccurred())
 			foo := list.Get("foo")
 			Expect(foo).ToNot(BeNil())
@@ -276,15 +276,45 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(string(group)).Should(Equal("foo:x:7000:foo\n"))
 
-			passdRaw, _ := fs.RawPath("/etc/passwd")
+			passwdRaw, _ := fs.RawPath("/etc/passwd")
 			list := xpasswd.NewUserList()
-			list.SetPath(passdRaw)
+			list.SetPath(passwdRaw)
 			Expect(list.Load()).ShouldNot(HaveOccurred())
 			foo := list.Get("foo")
 			Expect(foo).ToNot(BeNil())
 			gid, err := foo.GID()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(gid).To(Equal(7000))
+		})
+
+		It("ignores explicit gid when primary_group names an existing system group", func() {
+			// primary_group wins over an explicit gid because rewriting a
+			// well-known group's numeric gid would silently break every file
+			// already owned by that gid on the system.
+			// If the caller wants a pinned gid for the user's own group, they
+			// should leave primary_group empty.
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).Should(BeNil())
+			defer cleanup()
+
+			err = User(l, schema.Stage{
+				Users: map[string]schema.User{"foo": {
+					PasswordHash: `$fkekofe`,
+					PrimaryGroup: "root",
+					GID:          "6000",
+					Homedir:      "/run/foo",
+				}},
+			}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			group, err := fs.ReadFile("/etc/group")
+			Expect(err).ShouldNot(HaveOccurred())
+			// The user's primary group is root (looked up from the host); the
+			// explicit gid 6000 is intentionally NOT applied.
+			Expect(string(group)).ShouldNot(ContainSubstring(":6000:"))
 		})
 
 		It("returns an error when gid is not a number", func() {

--- a/pkg/schema/cloudinit/config.go
+++ b/pkg/schema/cloudinit/config.go
@@ -91,4 +91,5 @@ type User struct {
 	Shell                string   `yaml:"shell,omitempty"`
 	LockPasswd           bool     `yaml:"lock_passwd"`
 	UID                  string   `yaml:"uid"`
+	GID                  string   `yaml:"gid"`
 }

--- a/pkg/schema/loader_cloudinit.go
+++ b/pkg/schema/loader_cloudinit.go
@@ -56,6 +56,7 @@ func (cloudInit) Load(source string, s []byte, fs vfs.FS) (*YipConfig, error) {
 			NoLogInit:    u.NoLogInit,
 			Shell:        u.Shell,
 			UID:          u.UID,
+			GID:          u.GID,
 			LockPasswd:   u.LockPasswd,
 		}
 		sshKeys[u.Name] = u.SSHAuthorizedKeys

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -99,6 +99,7 @@ type User struct {
 	Shell             string   `yaml:"shell,omitempty"`
 	LockPasswd        bool     `yaml:"lock_passwd,omitempty"`
 	UID               string   `yaml:"uid,omitempty"`
+	GID               string   `yaml:"gid,omitempty"`
 }
 
 func (u User) Exists() bool {


### PR DESCRIPTION
Users could pin `uid` but not `gid`, so the primary group id ended up auto-generated or inherited from `primary_group` / a persistent home directory. On immutable systems that meant group ownership drifted across boots even when the uid was stable.

This adds a `gid` field to the users schema (native struct and cloud-init compat struct) and wires it through `createUser`. When set, `u.GID` is used verbatim ahead of the `primary_group` lookup and the home-directory gid reuse path. Explicit `gid` also counts as deterministic in `hasDeterministicUID`, so the ordering fix from kairos#2949 applies to gid-only users the same way it does to uid-only ones.

A few behaviors worth calling out:

- Explicit `gid` always wins over `primary_group` and home-dir reuse.
- Home-dir gid reuse still applies when no explicit `gid` is set — kairos#2949 semantics are preserved.
- When an explicit `gid` collides with a gid already reused from a persistent home dir, both users end up sharing that gid. Linux allows duplicate group gids and this keeps file ownership intact on both sides rather than silently rewriting one of them. There is a spec covering exactly this case.

README picks up the new `gid` field under `stages.<stageID>.[<stepN>].users` and, while there, documents the pre-existing but undocumented `uid` field.

Covered by four new Ginkgo specs in `pkg/plugins/user_test.go`: uid+gid combined, gid-only with generated uid, invalid gid returning a wrapped error, and the explicit-gid vs persistent-home-dir-gid coexistence case. `go test ./...` (109/109 plugin specs), `go vet ./...` and `go build ./...` all clean under `unshare -rm` with a tmpfs on `/run/lock`.

Fixes kairos-io/kairos#4212