### PR TITLE
feat(users): add subordinate ID ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ Adds or modifies users. Each entry is keyed by username and takes the following 
 - **lock_passwd**: Boolean. Lock the account password (equivalent to setting `!` in `/etc/shadow`).
 - **uid**: Numeric user id. When set, the user is created with this exact uid — no free-uid search and no home-directory-owner reuse. Useful on immutable systems where `/etc/passwd` is regenerated on every boot but `/home` is persisted, to keep file ownership stable.
 - **gid**: Numeric group id for the user's own primary group. When set (and `primary_group` is empty), the primary group is created with this exact gid. If `primary_group` is set too, that group's existing gid is used and `gid` is ignored.
+- **subuid**: Subordinate user ID range in `start:count` format. Yip creates or replaces the user's entry in `/etc/subuid`.
+- **subgid**: Subordinate group ID range in `start:count` format. Yip creates or replaces the user's entry in `/etc/subgid`.
 
 ```yaml
 stages:
@@ -391,6 +393,8 @@ stages:
             - github:mudler
         svc-app:
           uid: "12345"
+          subuid: "100000:65536"
+          subgid: "100000:65536"
           system: true
           shell: "/usr/sbin/nologin"
 ```

--- a/pkg/plugins/user.go
+++ b/pkg/plugins/user.go
@@ -6,6 +6,7 @@ import (
 	osuser "os/user"
 	"sort"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/mauromorales/xpasswd/pkg/users"
@@ -349,6 +350,51 @@ func setUserPass(fs vfs.FS, username, password string) error {
 	return nil
 }
 
+func setSubID(fs vfs.FS, path, username, idRange string) error {
+	if idRange == "" {
+		return nil
+	}
+	parts := strings.Split(idRange, ":")
+	if len(parts) != 2 {
+		return errors.Errorf("invalid %s range %q: expected start:count", strings.TrimPrefix(path, "/etc/"), idRange)
+	}
+	start, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return errors.Errorf("invalid %s range %q: start must be an unsigned integer", strings.TrimPrefix(path, "/etc/"), idRange)
+	}
+	count, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil || count == 0 {
+		return errors.Errorf("invalid %s range %q: count must be a positive integer", strings.TrimPrefix(path, "/etc/"), idRange)
+	}
+	const maxSubID = uint64(^uint32(0))
+	if start > maxSubID-(count-1) {
+		return errors.Errorf("invalid %s range %q: range exceeds the 32-bit id space", strings.TrimPrefix(path, "/etc/"), idRange)
+	}
+
+	content, err := fs.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "reading %s", path)
+	}
+
+	prefix := username + ":"
+	var output strings.Builder
+	for _, line := range strings.SplitAfter(string(content), "\n") {
+		record := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if !strings.HasPrefix(record, prefix) {
+			output.WriteString(line)
+		}
+	}
+	if output.Len() > 0 && !strings.HasSuffix(output.String(), "\n") {
+		output.WriteByte('\n')
+	}
+	output.WriteString(prefix + idRange + "\n")
+
+	if err := fs.WriteFile(path, []byte(output.String()), 0o644); err != nil {
+		return errors.Wrapf(err, "writing %s", path)
+	}
+	return nil
+}
+
 func User(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error {
 	var errs error
 
@@ -392,6 +438,13 @@ func User(l logger.Interface, s schema.Stage, fs vfs.FS, console Console) error 
 			if err := setUserPass(fs, r.Name, r.PasswordHash); err != nil {
 				return err
 			}
+		}
+
+		if err := setSubID(fs, "/etc/subuid", r.Name, r.SubUID); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		if err := setSubID(fs, "/etc/subgid", r.Name, r.SubGID); err != nil {
+			errs = multierror.Append(errs, err)
 		}
 
 		if len(s.Users[k].SSHAuthorizedKeys) > 0 {

--- a/pkg/plugins/user_test.go
+++ b/pkg/plugins/user_test.go
@@ -124,6 +124,120 @@ last:x:999:999:Test user for uid:/:/usr/bin/nologin
 		BeforeEach(func() {
 			testConsole.Reset()
 		})
+		It("writes subordinate uid and gid ranges idempotently", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+				"/etc/subuid": "# allocated by image\n\nother:100000:65536\nfoo:200000:65536\nfoo:300000:65536\n",
+				"/etc/subgid": "# allocated by image\n\nother:100000:65536\nfoo:200000:65536\n",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanup()
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"foo": {
+					PasswordHash: `$fkekofe`,
+					SubUID:       "400000:65536",
+					SubGID:       "500000:65536",
+				},
+			}}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			subuid, err := fs.ReadFile("/etc/subuid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(subuid)).To(Equal("# allocated by image\n\nother:100000:65536\nfoo:400000:65536\n"))
+
+			subgid, err := fs.ReadFile("/etc/subgid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(subgid)).To(Equal("# allocated by image\n\nother:100000:65536\nfoo:500000:65536\n"))
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"foo": {SubUID: "400000:65536", SubGID: "500000:65536"},
+			}}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			subuidAgain, err := fs.ReadFile("/etc/subuid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(subuidAgain).To(Equal(subuid))
+			subgidAgain, err := fs.ReadFile("/etc/subgid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(subgidAgain).To(Equal(subgid))
+		})
+
+		It("writes subordinate ranges for an existing user", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanup()
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"root": {SubUID: "100000:65536", SubGID: "100000:65536"},
+			}}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			subuid, err := fs.ReadFile("/etc/subuid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(subuid)).To(Equal("root:100000:65536\n"))
+			subgid, err := fs.ReadFile("/etc/subgid")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(subgid)).To(Equal("root:100000:65536\n"))
+		})
+
+		It("rejects malformed subordinate ranges", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanup()
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"root": {SubUID: "not-a-range"},
+			}}, fs, &testConsole)
+			Expect(err).To(MatchError(ContainSubstring("invalid subuid range")))
+			_, err = fs.ReadFile("/etc/subuid")
+			Expect(err).To(MatchError(ContainSubstring("no such file")))
+		})
+
+		It("rejects subordinate ranges that overflow the id space", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanup()
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"root": {SubUID: "4294967295:2"},
+			}}, fs, &testConsole)
+			Expect(err).To(MatchError(ContainSubstring("exceeds the 32-bit id space")))
+			_, err = fs.ReadFile("/etc/subuid")
+			Expect(err).To(MatchError(ContainSubstring("no such file")))
+		})
+
+		It("does not create subordinate id files when ranges are unset", func() {
+			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+				"/etc/passwd": existingPasswd,
+				"/etc/shadow": "",
+				"/etc/group":  "",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanup()
+
+			err = User(l, schema.Stage{Users: map[string]schema.User{
+				"root": {},
+			}}, fs, &testConsole)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = fs.ReadFile("/etc/subuid")
+			Expect(err).To(MatchError(ContainSubstring("no such file")))
+			_, err = fs.ReadFile("/etc/subgid")
+			Expect(err).To(MatchError(ContainSubstring("no such file")))
+		})
 		It("change user password", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{"/etc/passwd": existingPasswd,
 				"/etc/shadow": "",

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -100,6 +100,8 @@ type User struct {
 	LockPasswd        bool     `yaml:"lock_passwd,omitempty"`
 	UID               string   `yaml:"uid,omitempty"`
 	GID               string   `yaml:"gid,omitempty"`
+	SubUID            string   `yaml:"subuid,omitempty"`
+	SubGID            string   `yaml:"subgid,omitempty"`
 }
 
 func (u User) Exists() bool {

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -47,6 +47,20 @@ func loadYip(s string) *YipConfig {
 }
 
 var _ = Describe("Schema", func() {
+	It("loads subordinate uid and gid ranges", func() {
+		yipConfig := loadstdYip(`stages:
+  boot:
+    - users:
+        podman:
+          subuid: "100000:65536"
+          subgid: "200000:65536"
+`)
+
+		user := yipConfig.Stages["boot"][0].Users["podman"]
+		Expect(user.SubUID).To(Equal("100000:65536"))
+		Expect(user.SubGID).To(Equal("200000:65536"))
+	})
+
 	Context("Loading from dot notation", func() {
 		oneConfigwithGarbageS := "stages.foo[0].name=bar boo.baz"
 		twoConfigsS := "stages.foo[0].name=bar   stages.foo[0].commands[0]=baz"


### PR DESCRIPTION
## Summary

- add optional `subuid` and `subgid` user fields in `start:count` format
- create or replace each user mapping while preserving unrelated file content
- validate ranges and support both new and existing users

Closes kairos-io/kairos#2788

## Verification

- `GOTOOLCHAIN=local GOPROXY=direct go test ./pkg/schema`
- `GOTOOLCHAIN=local GOPROXY=direct go test ./pkg/plugins -ginkgo.focus="User"`
- `GOTOOLCHAIN=local GOPROXY=direct go vet ./pkg/schema ./pkg/plugins`
- `git diff --check upstream/master...HEAD`

The full plugin suite cannot complete on this host because unrelated tests require blocked Gist access and unavailable `mkfs` tools.